### PR TITLE
Add --optimize-legible compilation mode

### DIFF
--- a/compiler/src/Generate/Mode.hs
+++ b/compiler/src/Generate/Mode.hs
@@ -17,6 +17,8 @@ import qualified Elm.Compiler.Type.Extract as Extract
 import qualified Generate.JavaScript.Name as JsName
 
 
+import Lamdera ((&))
+import qualified Lamdera
 
 -- MODE
 
@@ -55,6 +57,11 @@ addToBuckets field frequency buckets =
 addToShortNames :: [Name.Name] -> ShortFieldNames -> ShortFieldNames
 addToShortNames fields shortNames =
   List.foldl' addField shortNames fields
+    & Lamdera.alternativeImplementationWhen (Lamdera.isLongNamesEnabled_)
+        (List.foldl' (\shortNames field ->
+            Map.insert field (JsName.fromLocal field) shortNames
+          ) shortNames fields
+        )
 
 
 addField :: ShortFieldNames -> Name.Name -> ShortFieldNames

--- a/extra/Lamdera.hs
+++ b/extra/Lamdera.hs
@@ -43,6 +43,10 @@ module Lamdera
   , disableWire
   , isWireEnabled
   , isWireEnabled_
+  , useLongNames_
+  , enableLongNames
+  , isLongNamesEnabled
+  , isLongNamesEnabled_
   , isTest
   , isLiveMode
   , setLiveMode
@@ -430,6 +434,24 @@ isWireEnabled = do
 isWireEnabled_ :: Bool
 isWireEnabled_ = unsafePerformIO $ isWireEnabled
 
+
+{-# NOINLINE useLongNames_ #-}
+useLongNames_ :: MVar Bool
+useLongNames_ = unsafePerformIO $ newMVar False
+
+enableLongNames :: IO ()
+enableLongNames = do
+  debug $ "🗜️ enableLongNames"
+  modifyMVar_ useLongNames_ (\_ -> pure True)
+
+{-# NOINLINE isLongNamesEnabled #-}
+isLongNamesEnabled :: IO Bool
+isLongNamesEnabled = do
+  readMVar useLongNames_
+
+{-# NOINLINE isLongNamesEnabled_ #-}
+isLongNamesEnabled_ :: Bool
+isLongNamesEnabled_ = unsafePerformIO $ isLongNamesEnabled
 
 
 isTest :: IO Bool

--- a/extra/Lamdera/CLI/Check.hs
+++ b/extra/Lamdera/CLI/Check.hs
@@ -590,6 +590,7 @@ buildProductionJsFiles root inProduction_ versionInfo = do
         , _report = Nothing
         , _docs = Nothing
         , _noWire = False
+        , _optimizeLegible = False
         }
 
     Make.run ["src" </> "LFR.elm"] $
@@ -600,6 +601,7 @@ buildProductionJsFiles root inProduction_ versionInfo = do
         , _report = Nothing
         , _docs = Nothing
         , _noWire = False
+        , _optimizeLegible = False
         }
 
     Lamdera.AppConfig.writeUsage
@@ -700,6 +702,7 @@ migrationCheck root nextVersion = do
           , _report = Nothing
           , _docs = Nothing
           , _noWire = False
+          , _optimizeLegible = False
           }
 
   -- @TODO this is because the migrationCheck does weird terminal stuff that mangles the display... how to fix this?

--- a/extra/Lamdera/Compile.hs
+++ b/extra/Lamdera/Compile.hs
@@ -41,6 +41,7 @@ makeOptimizedWithCleanup cleanup root path = do
           , _report = Nothing
           , _docs = Nothing
           , _noWire = False
+          , _optimizeLegible = False
           }
   wait r
   remove tmp
@@ -67,6 +68,7 @@ make_ root = do
           , _report = Nothing
           , _docs = Nothing
           , _noWire = False
+          , _optimizeLegible = False
           }
   wait r
   -- The compilation process ends by printing to terminal in a way that overwrites
@@ -95,6 +97,7 @@ makeDev root paths = do
           , _report = Nothing
           , _docs = Nothing
           , _noWire = False
+          , _optimizeLegible = False
           }
   wait r
   -- The compilation process ends by printing to terminal in a way that overwrites
@@ -130,6 +133,7 @@ makeHarnessDevJs root = do
           , _report = Nothing
           , _docs = Nothing
           , _noWire = False
+          , _optimizeLegible = False
           }
   wait r
   remove tmp

--- a/terminal/src/Main.hs
+++ b/terminal/src/Main.hs
@@ -210,6 +210,7 @@ make =
         |-- flag "report" Make.reportType "You can say --report=json to get error messages as JSON. This is only really useful if you are an editor plugin. Humans should avoid it!"
         |-- flag "docs" Make.docsFile "Generate a JSON file of documentation for a package. Eventually it will be possible to preview docs with `reactor` because it is quite hard to deal with these JSON files directly."
         |-- onOff "no-wire" "Explicitly disable Lamdera's wire codegen."
+        |-- onOff "optimize-legible" "Same as --optimize but without identifier shortening, handy for debugging optimised code or for when identifiers are more useful than smaller JS compilations."
   in
   Terminal.Command "make" Uncommon details example (zeroOrMore elmFile) makeFlags Make.run
 

--- a/terminal/src/Make.hs
+++ b/terminal/src/Make.hs
@@ -47,6 +47,7 @@ data Flags =
     , _report :: Maybe ReportType
     , _docs :: Maybe FilePath
     , _noWire :: Bool -- @LAMDERA
+    , _optimizeLegible :: Bool -- @LAMDERA
     }
 
 
@@ -68,10 +69,11 @@ type Task a = Task.Task Exit.Make a
 
 
 run :: [FilePath] -> Flags -> IO ()
-run paths flags@(Flags _ _ _ report _ noWire) =
+run paths flags@(Flags _ _ _ report _ noWire optimizeLegible) =
   do  style <- getStyle report
       maybeRoot <- Stuff.findRoot
       Lamdera.onlyWhen noWire Lamdera.disableWire
+      Lamdera.onlyWhen optimizeLegible Lamdera.enableLongNames
       Reporting.attemptWithStyle style Exit.makeToReport $
         case maybeRoot of
           Just root -> runHelp root paths style flags
@@ -79,10 +81,10 @@ run paths flags@(Flags _ _ _ report _ noWire) =
 
 
 runHelp :: FilePath -> [FilePath] -> Reporting.Style -> Flags -> IO (Either Exit.Make ())
-runHelp root paths style (Flags debug optimize maybeOutput _ maybeDocs _) =
+runHelp root paths style (Flags debug optimize maybeOutput _ maybeDocs _ optimizeLegible) =
   BW.withScope $ \scope ->
   Stuff.withRootLock root $ Task.run $
-  do  desiredMode <- getMode debug optimize
+  do  desiredMode <- getMode debug (optimize || optimizeLegible)
       details <- Task.eio Exit.MakeBadDetails (Details.load style scope root)
       case paths of
         [] ->
@@ -332,7 +334,7 @@ isDevNull name =
 
 -- Clone of run that uses attemptWithStyle_cleanup
 run_cleanup :: IO () -> [FilePath] -> Flags -> IO ()
-run_cleanup cleanup paths flags@(Flags _ _ _ report _ _) =
+run_cleanup cleanup paths flags@(Flags _ _ _ report _ _ _) =
   do  style <- getStyle report
       maybeRoot <- Stuff.findRoot
       Reporting.attemptWithStyle_cleanup cleanup style Exit.makeToReport $


### PR DESCRIPTION
By default Elm shortens (obfuscates) "field" names, but not custom type tags.

Now with Lamdera, if you use `--optimize-legible`, then record field names will not be shortened (before/after images for comparison below).

In theory this should make all runtime value instances between applications compatible where their definition is identical.

This is the first step in the spike for zero-serialisation Evergreen migrations.

![Screenshot 2024-04-09 at 21 52 21](https://github.com/lamdera/compiler/assets/102781/f6ca6e0d-2528-490a-81da-f97f015a3b6e)

![Screenshot 2024-04-09 at 21 58 36](https://github.com/lamdera/compiler/assets/102781/e1e4ad11-e179-47cc-babe-b3f920449e80)
