### PR TITLE
Add git submodules to the setup docs

### DIFF
--- a/extra/readme.md
+++ b/extra/readme.md
@@ -28,6 +28,7 @@ If in doubt, please ask!
 ```
 brew install gcc pkg-config      # some headers like 'linux/random.h' are implicitly required to build Haskell libs
 brew install icdiff   # used for nice side-by-side diffs in test output
+git submodule init && git submodule update # Get and update Git submodules for this project
 stack install hindent # used for debugging haskell values
 ```
 


### PR DESCRIPTION
Setting up submodules was missing in the setup documentation.

Without it, we get an error like the following:
```bash
$ stack ghci
/path/to/lamdera-compiler/vendor/elm-format/elm-format-markdown: getDirectoryContents:openDirStream: does not exist (No such file or directory)
```

Feel free to let me know if/how I should reword something, or to do it yourself, it's all good.