### PR TITLE
More elaborate injection for frontend upgrades

### DIFF
--- a/extra/Lamdera/Injection.hs
+++ b/extra/Lamdera/Injection.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Lamdera.Injection where
 
@@ -12,6 +13,9 @@ import qualified File
 import qualified System.Environment as Env
 import qualified System.Directory as Dir
 import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString as BS
+import Language.Haskell.TH (runIO)
+import Data.FileEmbed (bsToExp)
 import Data.Monoid (mconcat)
 import System.FilePath ((</>), takeDirectory)
 import qualified Data.Text as Text
@@ -177,151 +181,6 @@ injections outputType mode =
 
     previousVersion = show_ previousVersionInt
 
-    shouldProxy =
-      onlyIf (outputType == LamderaLive)
-        [text|
-          shouldProxy = $$author$$project$$LocalDev$$shouldProxy(msg)
-        |]
-
-    {-| The _Debug_toAnsiString function is for overriding the kernel cdoe for `Debug.toString`. The reason for doing so it handle SeqSet and SetDict which we want display as `SeqDict.fromList [ ... ]` and `SeqSet.fromList [ ... ]`. -}
-    debugToAnsiStringOverride =
-      [text|
-        function _Debug_toAnsiString(ansi, value)
-        {
-          if (typeof value === 'function')
-          {
-            return _Debug_internalColor(ansi, '<function>');
-          }
-
-          if (typeof value === 'boolean')
-          {
-            return _Debug_ctorColor(ansi, value ? 'True' : 'False');
-          }
-
-          if (typeof value === 'number')
-          {
-            return _Debug_numberColor(ansi, value + '');
-          }
-
-          if (value instanceof String)
-          {
-            return _Debug_charColor(ansi, "'" + _Debug_addSlashes(value, true) + "'");
-          }
-
-          if (typeof value === 'string')
-          {
-            return _Debug_stringColor(ansi, '"' + _Debug_addSlashes(value, false) + '"');
-          }
-
-          if (typeof value === 'object' && '$$' in value)
-          {
-            var tag = value.$$;
-
-            if (typeof tag === 'number')
-            {
-              return _Debug_internalColor(ansi, '<internals>');
-            }
-
-            if (tag[0] === '#')
-            {
-              var output = [];
-              for (var k in value)
-              {
-                if (k === '$$') continue;
-                output.push(_Debug_toAnsiString(ansi, value[k]));
-              }
-              return '(' + output.join(',') + ')';
-            }
-
-            if (tag === 'Set_elm_builtin')
-            {
-              return _Debug_ctorColor(ansi, 'Set')
-                + _Debug_fadeColor(ansi, '.fromList') + ' '
-                + _Debug_toAnsiString(ansi, $$elm$$core$$Set$$toList(value));
-            }
-
-            if (tag === 'RBNode_elm_builtin' || tag === 'RBEmpty_elm_builtin')
-            {
-              return _Debug_ctorColor(ansi, 'Dict')
-                + _Debug_fadeColor(ansi, '.fromList') + ' '
-                + _Debug_toAnsiString(ansi, $$elm$$core$$Dict$$toList(value));
-            }
-
-            if (tag === 'SeqSet_elm_builtin')
-            {
-              return _Debug_ctorColor(ansi, 'SeqSet')
-                + _Debug_fadeColor(ansi, '.fromList') + ' '
-                + _Debug_toAnsiString(ansi, $$lamdera$$containers$$SeqSet$$toList(value));
-            }
-
-            if (tag === 'SeqDict_elm_builtin')
-            {
-              return _Debug_ctorColor(ansi, 'SeqDict')
-                + _Debug_fadeColor(ansi, '.fromList') + ' '
-                + _Debug_toAnsiString(ansi, $$lamdera$$containers$$SeqDict$$toList(value));
-            }
-
-            if (tag === 'Array_elm_builtin')
-            {
-              return _Debug_ctorColor(ansi, 'Array')
-                + _Debug_fadeColor(ansi, '.fromList') + ' '
-                + _Debug_toAnsiString(ansi, $$elm$$core$$Array$$toList(value));
-            }
-
-            if (tag === '::' || tag === '[]')
-            {
-              var output = '[';
-
-              value.b && (output += _Debug_toAnsiString(ansi, value.a), value = value.b)
-
-              for (; value.b; value = value.b) // WHILE_CONS
-              {
-                output += ',' + _Debug_toAnsiString(ansi, value.a);
-              }
-              return output + ']';
-            }
-
-            var output = '';
-            for (var i in value)
-            {
-              if (i === '$$') continue;
-              var str = _Debug_toAnsiString(ansi, value[i]);
-              var c0 = str[0];
-              var parenless = c0 === '{' || c0 === '(' || c0 === '[' || c0 === '<' || c0 === '"' || str.indexOf(' ') < 0;
-              output += ' ' + (parenless ? str : '(' + str + ')');
-            }
-            return _Debug_ctorColor(ansi, tag) + output;
-          }
-
-          if (typeof DataView === 'function' && value instanceof DataView)
-          {
-            return _Debug_stringColor(ansi, '<' + value.byteLength + ' bytes>');
-          }
-
-          if (typeof File !== 'undefined' && value instanceof File)
-          {
-            return _Debug_internalColor(ansi, '<' + value.name + '>');
-          }
-
-          if (typeof value === 'object')
-          {
-            var output = [];
-            for (var key in value)
-            {
-              var field = key[0] === '_' ? key.slice(1) : key;
-              output.push(_Debug_fadeColor(ansi, field) + ' = ' + _Debug_toAnsiString(ansi, value[key]));
-            }
-            if (output.length === 0)
-            {
-              return '{}';
-            }
-            return '{ ' + output.join(', ') + ' }';
-          }
-
-          return _Debug_internalColor(ansi, '<internals>');
-        }
-      |]
-
     {-| This code overrides how == is handled in Elm for SeqDict and SeqSet.
         The code for handling Dict and Set is also injected here though the behavior is unchanged.
 
@@ -371,6 +230,9 @@ injections outputType mode =
               y = $$lamdera$$containers$$SeqSet$$toList(y);
             }
          |]
+
+    lamderaContainersExtensions_ =
+      Ext.Common.bsToText lamderaContainersExtensions
   in
   case outputType of
     -- NotLamdera was added when we fixed the hot loading of a new app version in the browser.
@@ -439,6 +301,9 @@ injections outputType mode =
 
     LamderaBackend ->
       [text|
+
+    $lamderaContainersExtensions_
+
     function _Platform_initialize(flagDecoder, args, init, update, subscriptions, stepperBuilder)
       {
         var result = A2(_Json_run, flagDecoder, _Json_wrap(args ? args['flags'] : undefined));
@@ -493,58 +358,6 @@ injections outputType mode =
         } : {};
       }
 
-    $debugToAnsiStringOverride
-
-    function _Debug_addSlashes(str, isChar)
-    {
-      var s = str
-        .replace(/\\/g, '\\\\')
-        .replace(/\n/g, '\\n')
-        .replace(/\t/g, '\\t')
-        .replace(/\r/g, '\\r')
-        .replace(/\v/g, '\\v')
-        .replace(/\0/g, '\\0');
-
-      if (isChar)
-      {
-        return s.replace(/\'/g, '\\\'');
-      }
-      else
-      {
-        return s.replace(/\"/g, '\\"');
-      }
-    }
-
-    function _Utils_eqHelp(x, y, depth, stack)
-    {
-      if (x === y)
-      {
-        return true;
-      }
-
-      if (typeof x !== 'object' || x === null || y === null)
-      {
-        typeof x === 'function' && $$elm$$core$$Debug$$crash(5);
-        return false;
-      }
-
-      if (depth > 100)
-      {
-        stack.push(_Utils_Tuple2(x,y));
-        return true;
-      }
-
-      $equalsOverride
-
-      for (var key in x)
-      {
-        if (!_Utils_eqHelp(x[key], y[key], depth + 1, stack))
-        {
-          return false;
-        }
-      }
-      return true;
-    }
     var isLamderaRuntime = typeof isLamdera !== 'undefined';
 
     function _Platform_initialize(flagDecoder, args, init, update, subscriptions, stepperBuilder)
@@ -664,6 +477,9 @@ injections outputType mode =
             |]
       in
       [text|
+
+    $lamderaContainersExtensions_
+
     function _Platform_initialize(flagDecoder, args, init, update, subscriptions, stepperBuilder)
       {
         var result = A2(_Json_run, flagDecoder, _Json_wrap(args ? args['flags'] : undefined));
@@ -1107,3 +923,14 @@ mainsInclude list mains =
         else False
     _ ->
       False
+
+{-|
+  Overrides to the following functions to add support for lamdera/containers SeqDict and SeqSet,
+  displaying as `SeqDict.fromList [ ... ]` and `SeqSet.fromList [ ... ]`
+
+  _Debug_toAnsiString
+  _Utils_eqHelp
+-}
+lamderaContainersExtensions :: BS.ByteString
+lamderaContainersExtensions =
+  $(bsToExp =<< runIO (Lamdera.Relative.readByteString "extra/Lamdera/Injection/lamdera-containers-extensions.js"))

--- a/extra/Lamdera/Injection/lamdera-containers-extensions.js
+++ b/extra/Lamdera/Injection/lamdera-containers-extensions.js
@@ -1,0 +1,185 @@
+function _Debug_toAnsiString(ansi, value)
+{
+  if (typeof value === 'function')
+  {
+    return _Debug_internalColor(ansi, '<function>');
+  }
+
+  if (typeof value === 'boolean')
+  {
+    return _Debug_ctorColor(ansi, value ? 'True' : 'False');
+  }
+
+  if (typeof value === 'number')
+  {
+    return _Debug_numberColor(ansi, value + '');
+  }
+
+  if (value instanceof String)
+  {
+    return _Debug_charColor(ansi, "'" + _Debug_addSlashes(value, true) + "'");
+  }
+
+  if (typeof value === 'string')
+  {
+    return _Debug_stringColor(ansi, '"' + _Debug_addSlashes(value, false) + '"');
+  }
+
+  if (typeof value === 'object' && '$$' in value)
+  {
+    var tag = value.$$;
+
+    if (typeof tag === 'number')
+    {
+      return _Debug_internalColor(ansi, '<internals>');
+    }
+
+    if (tag[0] === '#')
+    {
+      var output = [];
+      for (var k in value)
+      {
+        if (k === '$$') continue;
+        output.push(_Debug_toAnsiString(ansi, value[k]));
+      }
+      return '(' + output.join(',') + ')';
+    }
+
+    if (tag === 'Set_elm_builtin')
+    {
+      return _Debug_ctorColor(ansi, 'Set')
+        + _Debug_fadeColor(ansi, '.fromList') + ' '
+        + _Debug_toAnsiString(ansi, $$elm$$core$$Set$$toList(value));
+    }
+
+    if (tag === 'RBNode_elm_builtin' || tag === 'RBEmpty_elm_builtin')
+    {
+      return _Debug_ctorColor(ansi, 'Dict')
+        + _Debug_fadeColor(ansi, '.fromList') + ' '
+        + _Debug_toAnsiString(ansi, $$elm$$core$$Dict$$toList(value));
+    }
+
+    if (tag === 'SeqSet_elm_builtin')
+    {
+      return _Debug_ctorColor(ansi, 'SeqSet')
+        + _Debug_fadeColor(ansi, '.fromList') + ' '
+        + _Debug_toAnsiString(ansi, $$lamdera$$containers$$SeqSet$$toList(value));
+    }
+
+    if (tag === 'SeqDict_elm_builtin')
+    {
+      return _Debug_ctorColor(ansi, 'SeqDict')
+        + _Debug_fadeColor(ansi, '.fromList') + ' '
+        + _Debug_toAnsiString(ansi, $$lamdera$$containers$$SeqDict$$toList(value));
+    }
+
+    if (tag === 'Array_elm_builtin')
+    {
+      return _Debug_ctorColor(ansi, 'Array')
+        + _Debug_fadeColor(ansi, '.fromList') + ' '
+        + _Debug_toAnsiString(ansi, $$elm$$core$$Array$$toList(value));
+    }
+
+    if (tag === '::' || tag === '[]')
+    {
+      var output = '[';
+
+      value.b && (output += _Debug_toAnsiString(ansi, value.a), value = value.b)
+
+      for (; value.b; value = value.b) // WHILE_CONS
+      {
+        output += ',' + _Debug_toAnsiString(ansi, value.a);
+      }
+      return output + ']';
+    }
+
+    var output = '';
+    for (var i in value)
+    {
+      if (i === '$$') continue;
+      var str = _Debug_toAnsiString(ansi, value[i]);
+      var c0 = str[0];
+      var parenless = c0 === '{' || c0 === '(' || c0 === '[' || c0 === '<' || c0 === '"' || str.indexOf(' ') < 0;
+      output += ' ' + (parenless ? str : '(' + str + ')');
+    }
+    return _Debug_ctorColor(ansi, tag) + output;
+  }
+
+  if (typeof DataView === 'function' && value instanceof DataView)
+  {
+    return _Debug_stringColor(ansi, '<' + value.byteLength + ' bytes>');
+  }
+
+  if (typeof File !== 'undefined' && value instanceof File)
+  {
+    return _Debug_internalColor(ansi, '<' + value.name + '>');
+  }
+
+  if (typeof value === 'object')
+  {
+    var output = [];
+    for (var key in value)
+    {
+      var field = key[0] === '_' ? key.slice(1) : key;
+      output.push(_Debug_fadeColor(ansi, field) + ' = ' + _Debug_toAnsiString(ansi, value[key]));
+    }
+    if (output.length === 0)
+    {
+      return '{}';
+    }
+    return '{ ' + output.join(', ') + ' }';
+  }
+
+  return _Debug_internalColor(ansi, '<internals>');
+}
+
+function _Debug_addSlashes(str, isChar)
+{
+  var s = str
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t')
+    .replace(/\r/g, '\\r')
+    .replace(/\v/g, '\\v')
+    .replace(/\0/g, '\\0');
+
+  if (isChar)
+  {
+    return s.replace(/\'/g, '\\\'');
+  }
+  else
+  {
+    return s.replace(/\"/g, '\\"');
+  }
+}
+
+function _Utils_eqHelp(x, y, depth, stack)
+{
+  if (x === y)
+  {
+    return true;
+  }
+
+  if (typeof x !== 'object' || x === null || y === null)
+  {
+    typeof x === 'function' && $$elm$$core$$Debug$$crash(5);
+    return false;
+  }
+
+  if (depth > 100)
+  {
+    stack.push(_Utils_Tuple2(x,y));
+    return true;
+  }
+
+  $equalsOverride
+
+  for (var key in x)
+  {
+    if (!_Utils_eqHelp(x[key], y[key], depth + 1, stack))
+    {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
Runtime PR: https://github.com/lamdera/runtime/pull/29

The injection code already had quite a bit of if-else based on isBackend. Now, there are a lot more differences depending on backend vs frontend, so I if:ed the entire return value of the `injections` function. I think that is the easiest to understand. Then, for elm-pages (and who knows what else?) compatibility, I also added a branch that returns (basically) the current code.

The frontend injection is based on the demo I’ve shared earlier. It does two things:

- Makes `app.die()` complete (together with `app.bury()` (frontend only)). Most importantly, it removes all event listeners from the DOM elements rendered by the old Elm app. It also returns the last rendered virtual DOM node, so we can give it to the new app (see the next point).
- Makes `app.init()` accept a virtual DOM node to start from. This includes having to force the event listeners to be re-applied (according to virtual DOM diffing, some event listeners are already up-to-date, but in reality we have removed all event listeners from the DOM, so they need to be re-applied). And attaching new click listeners to `<a>` elements, so that SPA navigation works.

Small note about transferring the virtual DOM node from one app to another: The main reason we do that is because we want to retain all `map` and `lazy` nodes, which have no representation in the DOM and therefore cannot be recovered by turning the DOM back to virtual DOM (called virtualizing in Elm’s code). If those nodes are skipped, the first render is going to bail quickly due to different node types in the tree and unnecessarily re-render big chunks. Even if Elm’s virtual DOM was smarter around that, it’s still impossible to know if DOM attributes were set as attributes or properties in the Elm world (or even which properties to virtualize back). So transferring the virtual DOM node is the way to go.

Note elm-watch: Lamdera uses the “boot next app, transfer model, kill old app approach” while elm-watch uses “inject new view, update, subscriptions into current app“. While elm-watch’s approach avoid lots of complicated things that I had to do in this PR, it also has downsides for Lamdera’s use cases:

- elm-watch’s approach only works when you know that only user code can have changed. But for Lamdera, the compiler might have changed, outputting different Kernel code.
- elm-watch’s approach requires a pretty crazy hack in order to no leak memory. Lamdera’s approach only requires careful nulling of certain things.