### PR TITLE
Hot-reload ignores tests folder

### DIFF
--- a/ext-sentry/Ext/Filewatch.hs
+++ b/ext-sentry/Ext/Filewatch.hs
@@ -52,7 +52,8 @@ watch root action = do
              && not (List.isInfixOf "elm-stuff" filepath)
              && not (List.isInfixOf "node_modules" filepath)
             --  This is really dumb of you because some people use `/data/...` as a folder...
-            --  && not (List.isInfixOf "data" filepath)
+            -- && not (List.isInfixOf "data" filepath)
+             && not (List.isInfixOf "tests" filepath)
              && not (List.isInfixOf "elm-pkg-js-includes.min.js" filepath)
              && not (List.isInfixOf "tests" filepath)
 


### PR DESCRIPTION
In order for the end to end test generator to work, it needs to be able to store http requests somewhere. The `data` folder used to work but is no longer ignored by the file watcher. How about ignoring `tests` instead though? Changing a test shouldn't affect the app when running lamdera live?