### PR TITLE
Add support for lydell’s fork of elm/virtual-dom

### DIFF
--- a/compiler/src/Generate/Html.hs
+++ b/compiler/src/Generate/Html.hs
@@ -43,7 +43,7 @@ sandwich root moduleName javascript =
 
 <body>
 
-<pre id="elm"></pre>
+<pre data-elm id="elm"></pre>
 
 <script>
 try {

--- a/extra/Lamdera/Injection.hs
+++ b/extra/Lamdera/Injection.hs
@@ -543,14 +543,14 @@ injections outputType mode =
           };
 
           _VirtualDom_applyPatches = function(rootDomNode, oldVirtualNode, patches, eventNode) {
-            if (typeof _VirtualDom_wrap === 'function') { // For lydell’s vdom.
-              _VirtualDom_renderCount++;
-              var instance = rootDomNode.elmInstance || _VirtualDom_instanceCount++;
-              _VirtualDom_instance = '_' + instance;
-              var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode);
-              _VirtualDom_lastDomNode = diffReturn.w;
-              _VirtualDom_lastDomNode.elmInstance = instance;
-              _VirtualDom_instance = '';
+            if (typeof _VirtualDom_createTNode === 'function') { // For lydell’s vdom.
+              var tNode = rootDomNode.elmTree;
+              var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode, tNode);
+              _VirtualDom_lastDomNode = diffReturn.r;
+              if (_VirtualDom_lastDomNode !== rootDomNode) {
+                delete rootDomNode.elmTree;
+                _VirtualDom_lastDomNode.elmTree = tNode;
+              }
             } else {
               if (patches.length !== 0) {
                 _VirtualDom_addDomNodes(rootDomNode, oldVirtualNode, patches, eventNode);
@@ -714,7 +714,7 @@ injections outputType mode =
     function _VirtualDom_diff(x, y)
     {
       _VirtualDom_lastVNode = y;
-      if (typeof _VirtualDom_wrap === 'function') // For lydell’s vdom.
+      if (typeof _VirtualDom_createTNode === 'function') // For lydell’s vdom.
       {
         return y;
       }
@@ -727,15 +727,15 @@ injections outputType mode =
     var _VirtualDom_lastDomNode = null;
     function _VirtualDom_applyPatches(rootDomNode, oldVirtualNode, patches, eventNode)
     {
-      if (typeof _VirtualDom_wrap === 'function') // For lydell’s vdom.
+      if (typeof _VirtualDom_createTNode === 'function') // For lydell’s vdom.
       {
-        _VirtualDom_renderCount++;
-        var instance = rootDomNode.elmInstance || _VirtualDom_instanceCount++;
-        _VirtualDom_instance = '_' + instance;
-        var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode);
-        _VirtualDom_lastDomNode = diffReturn.w;
-        _VirtualDom_lastDomNode.elmInstance = instance;
-        _VirtualDom_instance = '';
+        var tNode = rootDomNode.elmTree;
+        var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode, tNode);
+        _VirtualDom_lastDomNode = diffReturn.r;
+        if (_VirtualDom_lastDomNode !== rootDomNode) {
+          delete rootDomNode.elmTree;
+          _VirtualDom_lastDomNode.elmTree = tNode;
+        }
         return _VirtualDom_lastDomNode;
       }
 

--- a/extra/Lamdera/Injection.hs
+++ b/extra/Lamdera/Injection.hs
@@ -545,8 +545,12 @@ injections outputType mode =
           _VirtualDom_applyPatches = function(rootDomNode, oldVirtualNode, patches, eventNode) {
             if (typeof _VirtualDom_wrap === 'function') { // For lydell’s vdom.
               _VirtualDom_renderCount++;
+              var instance = rootDomNode.elmInstance || _VirtualDom_instanceCount++;
+              _VirtualDom_instance = '_' + instance;
               var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode);
               _VirtualDom_lastDomNode = diffReturn.w;
+              _VirtualDom_lastDomNode.elmInstance = instance;
+              _VirtualDom_instance = '';
             } else {
               if (patches.length !== 0) {
                 _VirtualDom_addDomNodes(rootDomNode, oldVirtualNode, patches, eventNode);
@@ -726,8 +730,13 @@ injections outputType mode =
       if (typeof _VirtualDom_wrap === 'function') // For lydell’s vdom.
       {
         _VirtualDom_renderCount++;
+        var instance = rootDomNode.elmInstance || _VirtualDom_instanceCount++;
+        _VirtualDom_instance = '_' + instance;
         var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode);
-        return (_VirtualDom_lastDomNode = diffReturn.w);
+        _VirtualDom_lastDomNode = diffReturn.w;
+        _VirtualDom_lastDomNode.elmInstance = instance;
+        _VirtualDom_instance = '';
+        return _VirtualDom_lastDomNode;
       }
 
       if (patches.length === 0)

--- a/extra/Lamdera/Injection.hs
+++ b/extra/Lamdera/Injection.hs
@@ -484,6 +484,7 @@ injections outputType mode =
 
     $lamderaContainersExtensions_
 
+    var _VirtualDom_equalEvents; // For lydell’s vdom.
     function _Platform_initialize(flagDecoder, args, init, update, subscriptions, stepperBuilder)
       {
         var result = A2(_Json_run, flagDecoder, _Json_wrap(args ? args['flags'] : undefined));
@@ -542,10 +543,16 @@ injections outputType mode =
           };
 
           _VirtualDom_applyPatches = function(rootDomNode, oldVirtualNode, patches, eventNode) {
-            if (patches.length !== 0) {
-              _VirtualDom_addDomNodes(rootDomNode, oldVirtualNode, patches, eventNode);
+            if (typeof _VirtualDom_wrap === 'function') { // For lydell’s vdom.
+              _VirtualDom_renderCount++;
+              var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode);
+              _VirtualDom_lastDomNode = diffReturn.w;
+            } else {
+              if (patches.length !== 0) {
+                _VirtualDom_addDomNodes(rootDomNode, oldVirtualNode, patches, eventNode);
+              }
+              _VirtualDom_lastDomNode = _VirtualDom_applyPatchesHelp(rootDomNode, patches);
             }
-            _VirtualDom_lastDomNode = _VirtualDom_applyPatchesHelp(rootDomNode, patches);
             // Restore the event listeners on the <a> elements:
             var aElements = _VirtualDom_lastDomNode.getElementsByTagName('a');
             for (var i = 0; i < aElements.length; i++) {
@@ -703,6 +710,10 @@ injections outputType mode =
     function _VirtualDom_diff(x, y)
     {
       _VirtualDom_lastVNode = y;
+      if (typeof _VirtualDom_wrap === 'function') // For lydell’s vdom.
+      {
+        return y;
+      }
       var patches = [];
       _VirtualDom_diffHelp(x, y, patches, 0);
       return patches;
@@ -712,6 +723,13 @@ injections outputType mode =
     var _VirtualDom_lastDomNode = null;
     function _VirtualDom_applyPatches(rootDomNode, oldVirtualNode, patches, eventNode)
     {
+      if (typeof _VirtualDom_wrap === 'function') // For lydell’s vdom.
+      {
+        _VirtualDom_renderCount++;
+        var diffReturn = _VirtualDom_diffHelp(oldVirtualNode, patches, eventNode);
+        return (_VirtualDom_lastDomNode = diffReturn.w);
+      }
+
       if (patches.length === 0)
       {
         return (_VirtualDom_lastDomNode = rootDomNode);


### PR DESCRIPTION
This makes `lamdera live` work with my fork of elm/virtual-dom – read more here: https://github.com/lydell/elm-safe-virtual-dom.

However, this won’t work when migrating a production app from a version that uses the official elm/virtual-dom to a version that uses my fork. When migrating in production, we transfer the last-rendered virtual DOM node from the old app to the new. However, it won’t be compatible (since my fork naturally has changes). I think it’s possible to write a migration function that upgrades it, but I haven’t done that yet. I have not tested a production upgrade between two app versions, but I’ve gone through the code and it looks like other than that it should™️ work.

Another thing that won’t work in production is that your Elm code is compiled to JS on the server, where you don’t have the possibility to patch packages. However, Lamdera is interested in making this work and we’re collaborating on how to best do that.

---

Lamdera copies some functions from elm/virtual-dom, to make modifications to them. My fork of elm/virtual-dom also changes those functions. This PR copies those changes, and supports both the original version and my fork by `if`-ing on whether `_VirtualDom_wrap` exists (one of the new functions in my fork, arbitrary choice). This is for `_VirtualDom_applyPatches`, `_VirtualDom_diff` and `_VirtualDom_applyPatches`.

My fork also removes `_VirtualDom_equalEvents`, which Lamdera references. The solution is to just define the variable.

Finally, I added the `data-elm` attribute to `<pre id="elm"></pre>`. My fork only virtualizes elements with `data-elm`, for better compatibility with third-party scripts. 

`lamdera live` assumes that initializing the Elm app removes that element, and displays a message in it otherwise:
https://github.com/lamdera/compiler/blob/6415988a7468523843ed03869baff86a520d01c6/extra/live.js#L124-L126

By adding `data-elm` to it, Elm will virtualize it, and then realize that it isn’t needed and remove it (just like before).
