### PR TITLE
Direct fn calls: disable for cyclic calls

### DIFF
--- a/compiler/src/Generate/JavaScript.hs
+++ b/compiler/src/Generate/JavaScript.hs
@@ -652,7 +652,10 @@ makeArgLookup graph home name =
               Just (length args)
 
             _ ->
-              error (show names)
+              -- This disables direct function calls eg. for mutually recursive
+              -- functions (with or without partial application). These are
+              -- technically possible but not implemented here.
+              Nothing
 
         _ ->
           Nothing

--- a/test/Test/JsOutput.hs
+++ b/test/Test/JsOutput.hs
@@ -102,4 +102,99 @@ suite =
 
         Nothing ->
           crash "JS output could not be read."
+    , scope "direct function calls - mutual recursion" $ do
+      project <- io $ Lamdera.Relative.requireDir "test/direct-fn-calls-mutual-recursion"
+      let
+        elmHome = project ++ "/elm-home"
+        elmStuff = project ++ "/elm-stuff"
+
+      maybeJsOutput <- io $ do
+        rmdir elmHome
+        rmdir elmStuff
+
+        Test.Helpers.withElmHome elmHome $
+          Ext.Common.withProjectRoot project $
+            Make.run ["src/Main.elm"] $
+              Make.Flags
+                { _debug = False
+                , _optimize = True
+                , _output = Just (Make.JS "elm-stuff/tmp.js")
+                , _report = Nothing
+                , _docs = Nothing
+                , _noWire = True
+                , _optimizeLegible = False
+                }
+
+        fileContents <- readUtf8Text $ elmStuff ++ "/tmp.js"
+
+        rmdir elmHome
+        rmdir elmStuff
+
+        pure fileContents
+
+      case maybeJsOutput of
+        Just jsOutput ->
+          do
+            expectTextContains jsOutput "$Main$a2 = function (n) {"
+            expectTextContains jsOutput "$Main$cyclic$a1() {"
+            expectTextContains jsOutput "$Main$a1 ="
+            expectTextContains jsOutput "$Main$cyclic$a1 = function () {"
+            expectTextContains jsOutput "$Main$a1(1)"
+            expectTextContains jsOutput "$Main$a2(1)"
+
+            expectTextContains jsOutput "$Main$b2$ = function (m, n) {"
+            expectTextContains jsOutput "$Main$cyclic$b1()"
+            expectTextContains jsOutput "$Main$b2 = F2("
+            expectTextContains jsOutput "$Main$cyclic$b1 = "
+            expectTextContains jsOutput "$Main$b1 ="
+            expectTextContains jsOutput "$Main$cyclic$b1 = function () {"
+            expectTextContains jsOutput "$Main$b1, 1, 1)" -- A2
+            expectTextContains jsOutput "$Main$b2$(1, 1)"
+
+        Nothing ->
+          crash "JS output could not be read."
+    , scope "direct function calls - mutual recursion with partial application" $ do
+      project <- io $ Lamdera.Relative.requireDir "test/direct-fn-calls-mutual-recursion-partial-application"
+      let
+        elmHome = project ++ "/elm-home"
+        elmStuff = project ++ "/elm-stuff"
+
+      maybeJsOutput <- io $ do
+        rmdir elmHome
+        rmdir elmStuff
+
+        Test.Helpers.withElmHome elmHome $
+          Ext.Common.withProjectRoot project $
+            Make.run ["src/Main.elm"] $
+              Make.Flags
+                { _debug = False
+                , _optimize = True
+                , _output = Just (Make.JS "elm-stuff/tmp.js")
+                , _report = Nothing
+                , _docs = Nothing
+                , _noWire = True
+                , _optimizeLegible = False
+                }
+
+        fileContents <- readUtf8Text $ elmStuff ++ "/tmp.js"
+
+        rmdir elmHome
+        rmdir elmStuff
+
+        pure fileContents
+
+      case maybeJsOutput of
+        Just jsOutput ->
+          do
+            expectTextContains jsOutput "$Main$a2$ = function (x1, x2, x3, x4, x5) {"
+            expectTextContains jsOutput "$Main$a2 = F5"
+            expectTextContains jsOutput "$Main$cyclic$a1() {"
+            expectTextContains jsOutput "$Main$a2, 1, 2);"
+            expectTextContains jsOutput "$Main$a1 ="
+            expectTextContains jsOutput "$Main$cyclic$a1 = function () {"
+            expectTextContains jsOutput "$Main$a1, 3, 4, 5)" -- A3
+            expectTextContains jsOutput "$Main$a2$(1, 2, 3, 4, 5)"
+
+        Nothing ->
+          crash "JS output could not be read."
     ]

--- a/test/direct-fn-calls-mutual-recursion-partial-application/.gitignore
+++ b/test/direct-fn-calls-mutual-recursion-partial-application/.gitignore
@@ -1,0 +1,2 @@
+elm-stuff
+*.js

--- a/test/direct-fn-calls-mutual-recursion-partial-application/elm.json
+++ b/test/direct-fn-calls-mutual-recursion-partial-application/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
+            "elm/url": "1.0.0",
+            "lamdera/codecs": "1.0.0",
+            "lamdera/core": "1.0.0"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/test/direct-fn-calls-mutual-recursion-partial-application/src/Main.elm
+++ b/test/direct-fn-calls-mutual-recursion-partial-application/src/Main.elm
@@ -1,0 +1,25 @@
+module Main exposing (main)
+
+import Html exposing (Html)
+
+
+main : Html msg
+main =
+    Html.div []
+        [ Html.text (a1 3 4 5)
+        , Html.text (a2 1 2 3 4 5)
+        ]
+
+
+a1 : Int -> Int -> Int -> String
+a1 =
+    a2 1 2
+
+
+a2 : Int -> Int -> Int -> Int -> Int -> String
+a2 x1 x2 x3 x4 x5 =
+    if True then
+        "done"
+
+    else
+        a1 3 4 5

--- a/test/direct-fn-calls-mutual-recursion/.gitignore
+++ b/test/direct-fn-calls-mutual-recursion/.gitignore
@@ -1,0 +1,2 @@
+elm-stuff
+*.js

--- a/test/direct-fn-calls-mutual-recursion/elm.json
+++ b/test/direct-fn-calls-mutual-recursion/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
+            "elm/url": "1.0.0",
+            "lamdera/codecs": "1.0.0",
+            "lamdera/core": "1.0.0"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/test/direct-fn-calls-mutual-recursion/src/Main.elm
+++ b/test/direct-fn-calls-mutual-recursion/src/Main.elm
@@ -1,0 +1,41 @@
+module Main exposing (main)
+
+import Html exposing (Html)
+
+
+main : Html msg
+main =
+    Html.div []
+        [ Html.text (a1 1)
+        , Html.text (a2 1)
+        , Html.text (b1 1 1)
+        , Html.text (b2 1 1)
+        ]
+
+
+a1 : Int -> String
+a1 =
+    a2
+
+
+a2 : Int -> String
+a2 n =
+    if n > 0 then
+        a1 (n - 1)
+
+    else
+        "done"
+
+
+b1 : Int -> Int -> String
+b1 =
+    b2
+
+
+b2 : Int -> Int -> String
+b2 m n =
+    if n > 0 then
+        b1 (m - 1) (n - 1)
+
+    else
+        "done"


### PR DESCRIPTION
**Quick Summary:** Cyclic functions were not correctly analyzed for makeArgLookup (finding the number of arguments of a function).


## SSCCE

```elm
module Main exposing (main)

import Html exposing (Html)


main : Html msg
main =
    Html.div []
        [ Html.text (a1 1 1)
        , Html.text (a2 1 1)
        , Html.text (b1 3 4 5)
        , Html.text (b2 1 2 3 4 5)
        ]


a1 : Int -> Int -> String
a1 =
    a2


a2 : Int -> Int -> String
a2 m n =
    if n > 0 then
        a1 (m - 1) (n - 1)

    else
        "done"


b1 : Int -> Int -> Int -> String
b1 =
    b2 1 2


b2 : Int -> Int -> Int -> Int -> Int -> String
b2 x1 x2 x3 x4 x5 =
    if True then
        "done"

    else
        b1 3 4 5
```

- **Elm:** `lamdera/compiler` @ https://github.com/lamdera/compiler/commit/7bb3b2f36a3567df37ebd8215ec7c9a0b9b35883

## Additional Details

Found by @pithub [here](https://discord.com/channels/534524278847045633/1350075725268652073/1354816347607138305)

I attempted to optimize these cases in https://github.com/lamdera/compiler/pull/43 but got stuck on actually generating the needed JavaScript, making sure generated arg names don't collide with user-given ones, etc.

It should be technically possible to do this but it's not a 5-minute fix.

Until then we do [what Gren did](https://github.com/gren-lang/compiler/commit/512cdd89c82ca106a65d17115aaa9e205d250a11) and just don't optimize cyclic function definitions in this way and fall back to AX/FX.