### PR TITLE
Added Lamdera alternative implementation for HTML generation.

### DIFF
--- a/compiler/src/Generate/Html.hs
+++ b/compiler/src/Generate/Html.hs
@@ -17,9 +17,50 @@ import qualified Lamdera.UiSourceMap
 
 -- SANDWICH
 
-
+-- @LAMDERA root :: FilePath parameter added.
 sandwich :: FilePath -> Name.Name -> B.Builder -> B.Builder
 sandwich root moduleName javascript =
+  Lamdera.alternativeImplementationWhen Lamdera.isLamdera_ (sandwich_ root moduleName javascript) $
+  let name = Name.toBuilder moduleName in
+  [r|<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>|] <> name <> [r|</title>
+  <style>body { padding: 0; margin: 0; }</style>
+</head>
+
+<body>
+
+<pre id="elm"></pre>
+
+<script>
+try {
+|] <> javascript <> [r|
+
+  var app = Elm.|] <> name <> [r|.init({ node: document.getElementById("elm") });
+}
+catch (e)
+{
+  // display initialization errors (e.g. bad flags, infinite recursion)
+  var header = document.createElement("h1");
+  header.style.fontFamily = "monospace";
+  header.innerText = "Initialization Error";
+  var pre = document.getElementById("elm");
+  document.body.insertBefore(header, pre);
+  pre.innerText = e;
+  throw e;
+}
+</script>
+
+</body>
+</html>|]
+
+
+-- @LAMDERA
+
+sandwich_ :: FilePath -> Name.Name -> B.Builder -> B.Builder
+sandwich_ root moduleName javascript =
   let
     name = Name.toBuilder moduleName
 

--- a/elm.cabal
+++ b/elm.cabal
@@ -320,6 +320,7 @@ Executable lamdera
         Test.Wire
         Test.JsOutput
         Test.WebGL
+        Test.BackwardsCompat
         Test.Lamdera.Evergreen.TestMigrationHarness
         Test.Lamdera.Evergreen.TestMigrationGenerator
 

--- a/extra/Lamdera/Compile.hs
+++ b/extra/Lamdera/Compile.hs
@@ -112,6 +112,30 @@ makeDev_ path =
   makeDev (FP.takeDirectory path) [path]
 
 
+makeDevHtml :: FilePath -> [FilePath] -> IO ()
+makeDevHtml root paths = do
+  debug $ "🏗   makeDevHtml: lamdera make " <> root <> "/"
+
+  r <- async $
+    Ext.Common.withProjectRoot root $ do
+      Make.run paths $
+        Make.Flags
+          { _debug = True
+          , _optimize = False
+          , _output = Nothing
+          , _report = Nothing
+          , _docs = Nothing
+          , _noWire = False
+          , _optimizeLegible = False
+          }
+  wait r
+  -- The compilation process ends by printing to terminal in a way that overwrites
+  -- the progress bar – which messes with subsequent output if it gets written to
+  -- stdout too quickly, as it doesn't seem to flush fast enough. Adding a small
+  -- delay seems to solve the problem.
+  sleep 10
+
+
 -- Runs `lamdera make` of harness file with JS file output
 makeHarnessDevJs :: FilePath -> IO ()
 makeHarnessDevJs root = do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -21,7 +21,11 @@ import qualified Test.Ext.ElmPages.Check
 import qualified Test.TypeHashes
 import qualified Test.JsOutput
 import qualified Test.WebGL
+<<<<<<< HEAD
 import qualified Test.Lamdera.Live
+=======
+import qualified Test.BackwardsCompat
+>>>>>>> bdcb71f7 (Test Lamdera HTML injections don't happen on vanilla Elm projects)
 
 import qualified Test.Lamdera.Evergreen.TestMigrationHarness
 import qualified Test.Lamdera.Evergreen.TestMigrationGenerator
@@ -161,4 +165,5 @@ allTests =
     , scope "Test.WebGL -> " $ Test.WebGL.suite
     , scope "Test.JsOutput -> " $ Test.JsOutput.suite
     , scope "Test.Lamdera.Live -> " $ Test.Lamdera.Live.suite
+    , scope "Test.BackwardsCompat -> " $ Test.BackwardsCompat.suite
     ]

--- a/test/Test/BackwardsCompat.hs
+++ b/test/Test/BackwardsCompat.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.BackwardsCompat where
+
+import EasyTest
+import Ext.Common
+import Lamdera hiding ((&))
+import Test.Helpers
+import qualified Lamdera.Compile
+
+suite :: Test ()
+suite = tests $
+  [ scope "an vanilla elm project compiled with lamdera should not inject lamdera html modifications" $
+    let
+      project = "./test/scenario-empty-elm-init"
+      bashInScenario c = bash $ "cd " ++ project ++ " && " ++ c
+
+      setup = do
+        rmdir $ project ++ "/elm-home"
+        rmdir $ project ++ "/elm-stuff"
+
+      cleanup _ = do
+        pure ()
+
+      test _ = do
+        io $ do
+          withEnvVars [("ELM_HOME", project ++ "/elm-home")] $
+            Lamdera.Compile.makeDevHtml project ["src/Main.elm"]
+
+        htmlM <- io $ readUtf8Text $ project ++ "/index.html"
+
+        case htmlM of
+          Nothing -> crash "index.html not found"
+          Just html -> do
+            expectTextDoesNotContain html "apple-mobile-web-app-capable"
+
+    in
+    using setup cleanup test
+  ]


### PR DESCRIPTION
Added Lamdera alternative implementation for HTML generation only when building a Lamdera project, not regular Elm.

This means you can do `lamdera make src/Main.elm` with a `Browser.sandbox/document/application` and get an index.html output file that will run that application.

Without this change some Lamdera extra stuff gets put in the HTML for running a Lamdera Live application, and the application hangs on startup looking for a websocket connection to the backend.

The alternative implementation is wrapped like this:

    Lamdera.alternativeImplementationWhen Lamdera.isLamdera_ (sandwich_ root moduleName javascript) $
    
 So contingent on the `Lamdera.isLamdera_` condition being true. This is true when the elm.json contains lamdera/core as a package, and there are `Types.elm` and `Backend.elm` files under src/.
 
 Reason for this PR is the aim of making lamdera a drop-in replacement for Elm. Html generation is probably not used as much with Elm in production compared with generating an elm.json and a custom Html document, but worth consdering for completeness of providing a drop-in replacement for the `make` command.