### PR TITLE
Set user-agent to "node" for backend requests

### DIFF
--- a/extra/Lamdera/ReverseProxy.hs
+++ b/extra/Lamdera/ReverseProxy.hs
@@ -118,8 +118,11 @@ modReq newPathInfo hostname request =
         request
           & requestHeaders
           & fmap (\(header, contents) ->
-            if header == hHost
-              then (header, T.encodeUtf8 hostname)
-              else (header, contents)
-          )
+              if header == hHost then
+                (header, T.encodeUtf8 hostname)
+              else if header == hUserAgent then
+                (header, "node")
+              else
+                (header, contents)
+            )
     }


### PR DESCRIPTION
Currently the http proxy for lamdera live uses whatever user-agent the browser sends it. This causes problems when working with Discord's http API because it will reject requests if they look like they are coming from a browser. So this PR sets the user-agent to "node" for backend requests*

*As best as it can. There's the long standing issue with http tasks inside Task.andThen not getting handled