### PR TITLE
Fix modified elm.json bug introduced in #46

### DIFF
--- a/builder/src/Build.hs
+++ b/builder/src/Build.hs
@@ -58,6 +58,9 @@ import qualified Reporting.Render.Type.Localizer as L
 import qualified Stuff
 
 
+import Lamdera
+
+
 
 -- ENVIRONMENT
 
@@ -1120,7 +1123,9 @@ crawlRoot env@(Env _ _ projectType _ buildID _ _) mvar root =
             Right modul@(Src.Module _ _ _ imports values _ _ _ _) ->
               do  let deps = map Src.getImportName imports
                   let local = Details.Local path time deps (any isMain values) buildID buildID
-                  crawlDeps env mvar deps (SOutsideOk local source modul)
+                  Lamdera.alternativeImplementationWhen (lamderaIsLiveHarnessModule modul)
+                    (crawlDeps (lamderaLiveHarnessEnv env) mvar deps (SOutsideOk local source modul)) $
+                    crawlDeps env mvar deps (SOutsideOk local source modul)
 
             Left syntaxError ->
               return $ SOutsideErr $
@@ -1249,3 +1254,21 @@ addOutside root modules =
     ROutsideOk name iface objs -> Fresh name iface objs : modules
     ROutsideErr _              -> modules
     ROutsideBlocked            -> modules
+
+
+
+-- @LAMDERA
+
+
+{- Alternative implementation extended with support for additional
+source directories when compiling the Lamdera Live harness module
+-}
+lamderaIsLiveHarnessModule :: Src.Module -> Bool
+lamderaIsLiveHarnessModule modul =
+  Src.getName modul == "LocalDev"
+
+
+lamderaLiveHarnessEnv :: Env -> Env
+lamderaLiveHarnessEnv env =
+  -- adds the Lamdera cache directory as an additional source directory
+  env { _srcDirs = AbsoluteSrcDir (Lamdera.lamderaCache $ _root env) : _srcDirs env }

--- a/builder/src/Build.hs
+++ b/builder/src/Build.hs
@@ -1123,9 +1123,9 @@ crawlRoot env@(Env _ _ projectType _ buildID _ _) mvar root =
             Right modul@(Src.Module _ _ _ imports values _ _ _ _) ->
               do  let deps = map Src.getImportName imports
                   let local = Details.Local path time deps (any isMain values) buildID buildID
-                  Lamdera.alternativeImplementationWhen (lamderaIsLiveHarnessModule modul)
-                    (crawlDeps (lamderaLiveHarnessEnv env) mvar deps (SOutsideOk local source modul)) $
-                    crawlDeps env mvar deps (SOutsideOk local source modul)
+                  crawlDeps env mvar deps (SOutsideOk local source modul)
+                    & Lamdera.alternativeImplementationWhen (lamderaIsLiveHarnessModule modul)
+                        (crawlDeps (lamderaLiveHarnessEnv env) mvar deps (SOutsideOk local source modul))
 
             Left syntaxError ->
               return $ SOutsideErr $

--- a/builder/src/Elm/Outline.hs
+++ b/builder/src/Elm/Outline.hs
@@ -202,7 +202,7 @@ read root shouldCheckLamdera =
                 then Left Exit.OutlineNoPkgCore
                 else Right outline
 
-            App (AppOutline version srcDirs@(NE.List srcHead srcTail) direct indirect testDirect testIndirect)
+            App (AppOutline _ srcDirs direct indirect _ _)
               | Map.notMember Pkg.core direct ->
                   return $ Left Exit.OutlineNoAppCore
 
@@ -219,9 +219,8 @@ read root shouldCheckLamdera =
                           do  maybeDups <- detectDuplicates root (NE.toList srcDirs)
                               case maybeDups of
                                 Nothing ->
-                                  let newSrcDirs = NE.List srcHead (AbsoluteSrcDir (Lamdera.lamderaCache root) : srcTail) in
                                   Lamdera.alternativeImplementationPassthrough (Lamdera.Checks.runChecks root shouldCheckLamdera direct) $
-                                  return $ Right (App (AppOutline version newSrcDirs direct indirect testDirect testIndirect))
+                                  return $ Right outline
 
                                 Just (canonicalDir, (dir1,dir2)) ->
                                   return $ Left (Exit.OutlineHasDuplicateSrcDirs canonicalDir dir1 dir2)


### PR DESCRIPTION
#46 introduced the ability to use multiple modules in `LocalDev.elm`. This was achieved by adding `elm-stuff/lamdera` as an extra source directory to the `Outline` when reading the user's`elm.json` file.

Unfortunately, with commands like `lamdera install`, the modified outline can sometimes be mistakenly written back to the filesystem. This can then result in errors like:
```
-- AMBIGUOUS NAME ----------------------- elm-stuff/lamdera/LamderaCheckBoth.elm

This usage of `T2.ToFrontend` is ambiguous.
```

With this change, the additional source directory is added later, specifically in the `Build.hs` `Env` data structure, which is not written back to the filesystem. Additionally, the change only takes effect when the `LocalDev.elm` module is compiled, and not with commands like `lamdera install`.
