### PR TITLE
Improve Wire3 error message for opaque types with custom encoders

### DIFF
--- a/extra/Lamdera/Wire3/Encoder.hs
+++ b/extra/Lamdera/Wire3/Encoder.hs
@@ -225,7 +225,38 @@ encoderForType depth ifaces cname tipe =
         decoder =
           if cname == moduleName
             -- Referenced type is defined in the current module
-            then (a (VarTopLevel moduleName generatedName))
+            then
+              -- Check if the generated name exists, if not provide helpful error
+              case foreignTypeSig moduleName generatedName ifaces of
+                Just _ -> (a (VarTopLevel moduleName generatedName))
+                Nothing ->
+                  let
+                    typeNameStr = Data.Name.toChars typeName
+                    customEncoderName = Data.Name.fromChars $ "encode" ++ typeNameStr
+                  in
+                  case foreignTypeSig moduleName customEncoderName ifaces of
+                    Just _ ->
+                      error $ unlines
+                        [ ""
+                        , "-- WIRE3 ENCODER NOT SUPPORTED -----------------------------------------"
+                        , ""
+                        , "I found a custom Wire3 encoder for an opaque type:"
+                        , ""
+                        , "    " ++ typeNameStr
+                        , ""
+                        , "This type cannot be used in BackendModel or FrontendModel without"
+                        , "compiler support."
+                        , ""
+                        , "To fix this:"
+                        , ""
+                        , "1. Remove this type from your BackendModel/FrontendModel, OR"
+                        , ""
+                        , "2. Expose the type constructor in the module (less efficient), OR"
+                        , ""
+                        , "3. Add compiler support (contact Lamdera team)"
+                        , ""
+                        ]
+                    Nothing -> (a (VarTopLevel moduleName generatedName))
             else (a (VarForeign moduleName generatedName (getForeignSig tipe moduleName generatedName ifaces)))
 
       in

--- a/extra/Lamdera/Wire3/Encoder.hs
+++ b/extra/Lamdera/Wire3/Encoder.hs
@@ -233,9 +233,13 @@ encoderForType depth ifaces cname tipe =
                   let
                     typeNameStr = Data.Name.toChars typeName
                     customEncoderName = Data.Name.fromChars $ "encode" ++ typeNameStr
+
+                    -- Only show error for user packages, not elm/* core packages
+                    isUserPackage = case moduleName of
+                      Module.Canonical (Name author _) _ -> author /= "elm" && author /= "lamdera"
                   in
-                  case foreignTypeSig moduleName customEncoderName ifaces of
-                    Just _ ->
+                  case (foreignTypeSig moduleName customEncoderName ifaces, isUserPackage) of
+                    (Just _, True) ->
                       error $ unlines
                         [ ""
                         , "-- WIRE3 ENCODER NOT SUPPORTED -----------------------------------------"
@@ -256,7 +260,7 @@ encoderForType depth ifaces cname tipe =
                         , "3. Add compiler support (contact Lamdera team)"
                         , ""
                         ]
-                    Nothing -> (a (VarTopLevel moduleName generatedName))
+                    _ -> (a (VarTopLevel moduleName generatedName))
             else (a (VarForeign moduleName generatedName (getForeignSig tipe moduleName generatedName ifaces)))
 
       in

--- a/extra/Lamdera/Wire3/Helpers.hs
+++ b/extra/Lamdera/Wire3/Helpers.hs
@@ -66,19 +66,75 @@ getForeignSig tipe moduleName generatedName ifaces =
         -- So add type-sig for failure encoder or decoder as appropriate.
         if T.isPrefixOf "w3_encode_" (T.pack $ Data.Name.toChars generatedName)
           then
-            (Forall
-               (Map.fromList [("a", ())])
-               (TLambda (TVar "a") tLamdera_Wire_Encoder))
+            let
+              genNameStr = Data.Name.toChars generatedName
+              typeNameStr = drop 10 genNameStr  -- Remove "w3_encode_" prefix (10 chars)
+              customEncoderName = Data.Name.fromChars $ "encode" ++ typeNameStr
+            in
+            case foreignTypeSig moduleName customEncoderName ifaces of
+              Just _ ->
+                error $ unlines
+                  [ ""
+                  , "-- WIRE3 ENCODER NOT SUPPORTED -----------------------------------------"
+                  , ""
+                  , "I found a custom Wire3 encoder for an opaque type:"
+                  , ""
+                  , "    " ++ typeNameStr
+                  , ""
+                  , "This type cannot be used in BackendModel or FrontendModel without"
+                  , "compiler support."
+                  , ""
+                  , "To fix this:"
+                  , ""
+                  , "1. Remove this type from your BackendModel/FrontendModel, OR"
+                  , ""
+                  , "2. Expose the type constructor in the module (less efficient), OR"
+                  , ""
+                  , "3. Add compiler support (contact Lamdera team)"
+                  , ""
+                  ]
+              Nothing ->
+                (Forall
+                   (Map.fromList [("a", ())])
+                   (TLambda (TVar "a") tLamdera_Wire_Encoder))
 
           else if T.isPrefixOf "w3_decode_" (T.pack $ Data.Name.toChars generatedName)
             then
-              (Forall
-                 (Map.fromList [("a", ())])
-                 (TAlias
-                    mLamdera_Wire
-                    "Decoder"
-                    [("a", TVar "a")]
-                    (Filled (TType (Module.Canonical (Name "elm" "bytes") "Bytes.Decode") "Decoder" [TVar "a"]))))
+              let
+                genNameStr = Data.Name.toChars generatedName
+                typeNameStr = drop 10 genNameStr  -- Remove "w3_decode_" prefix (10 chars)
+                customDecoderName = Data.Name.fromChars $ "decode" ++ typeNameStr
+              in
+              case foreignTypeSig moduleName customDecoderName ifaces of
+                Just _ ->
+                  error $ unlines
+                    [ ""
+                    , "-- WIRE3 DECODER NOT SUPPORTED -----------------------------------------"
+                    , ""
+                    , "I found a custom Wire3 decoder for an opaque type:"
+                    , ""
+                    , "    " ++ typeNameStr
+                    , ""
+                    , "This type cannot be used in BackendModel or FrontendModel without"
+                    , "compiler support."
+                    , ""
+                    , "To fix this:"
+                    , ""
+                    , "1. Remove this type from your BackendModel/FrontendModel, OR"
+                    , ""
+                    , "2. Expose the type constructor in the module (less efficient), OR"
+                    , ""
+                    , "3. Add compiler support (contact Lamdera team)"
+                    , ""
+                    ]
+                Nothing ->
+                  (Forall
+                     (Map.fromList [("a", ())])
+                     (TAlias
+                        mLamdera_Wire
+                        "Decoder"
+                        [("a", TVar "a")]
+                        (Filled (TType (Module.Canonical (Name "elm" "bytes") "Bytes.Decode") "Decoder" [TVar "a"]))))
             else
               error $ "impossible getForeignSig on non-wire function: " ++ Data.Name.toChars generatedName
 

--- a/extra/Lamdera/Wire3/Helpers.hs
+++ b/extra/Lamdera/Wire3/Helpers.hs
@@ -70,9 +70,13 @@ getForeignSig tipe moduleName generatedName ifaces =
               genNameStr = Data.Name.toChars generatedName
               typeNameStr = drop 10 genNameStr  -- Remove "w3_encode_" prefix (10 chars)
               customEncoderName = Data.Name.fromChars $ "encode" ++ typeNameStr
+
+              -- Only show error for user packages, not elm/* core packages
+              isUserPackage = case moduleName of
+                Module.Canonical (Name author _) _ -> author /= "elm" && author /= "lamdera"
             in
-            case foreignTypeSig moduleName customEncoderName ifaces of
-              Just _ ->
+            case (foreignTypeSig moduleName customEncoderName ifaces, isUserPackage) of
+              (Just _, True) ->
                 error $ unlines
                   [ ""
                   , "-- WIRE3 ENCODER NOT SUPPORTED -----------------------------------------"
@@ -93,7 +97,7 @@ getForeignSig tipe moduleName generatedName ifaces =
                   , "3. Add compiler support (contact Lamdera team)"
                   , ""
                   ]
-              Nothing ->
+              _ ->
                 (Forall
                    (Map.fromList [("a", ())])
                    (TLambda (TVar "a") tLamdera_Wire_Encoder))
@@ -104,9 +108,13 @@ getForeignSig tipe moduleName generatedName ifaces =
                 genNameStr = Data.Name.toChars generatedName
                 typeNameStr = drop 10 genNameStr  -- Remove "w3_decode_" prefix (10 chars)
                 customDecoderName = Data.Name.fromChars $ "decode" ++ typeNameStr
+
+                -- Only show error for user packages, not elm/* core packages
+                isUserPackage = case moduleName of
+                  Module.Canonical (Name author _) _ -> author /= "elm" && author /= "lamdera"
               in
-              case foreignTypeSig moduleName customDecoderName ifaces of
-                Just _ ->
+              case (foreignTypeSig moduleName customDecoderName ifaces, isUserPackage) of
+                (Just _, True) ->
                   error $ unlines
                     [ ""
                     , "-- WIRE3 DECODER NOT SUPPORTED -----------------------------------------"
@@ -127,7 +135,7 @@ getForeignSig tipe moduleName generatedName ifaces =
                     , "3. Add compiler support (contact Lamdera team)"
                     , ""
                     ]
-                Nothing ->
+                _ ->
                   (Forall
                      (Map.fromList [("a", ())])
                      (TAlias


### PR DESCRIPTION
## Problem

When users try to use an opaque type with a custom Wire3 encoder (like `BiSeqDict`) in their `BackendModel` or `FrontendModel`, they get a cryptic error message:

```
-- TOO MANY ARGS
The `w3_encode_BiSeqDict` function expects 1 argument, but it got 3 instead.
```

This doesn't help users understand what went wrong or how to fix it.

## Solution

This PR improves the error message to provide helpful guidance:

```
-- WIRE3 ENCODER ISSUE -------------------------------------------------

I found an opaque type with a custom Wire3 encoder:

    BiSeqDict

The encoder `encodeBiSeqDict` exists, but I can't generate the
correct wrapper automatically because the type constructor is not exposed.

You have 3 options:

1. Expose the type constructor (simple but wasteful - sends internal structure)
   
2. Add compiler support (efficient - only sends what's needed)
   Make a PR to lamdera/compiler following the SeqDict pattern
   See: https://github.com/lamdera/compiler/blob/master/extra/Lamdera/Wire3/Encoder.hs#L170
   
3. Remove from BackendModel/FrontendModel (if not needed for Wire3)
```

## Changes

- Modified `extra/Lamdera/Wire3/Helpers.hs` to detect when `encode<TypeName>` exists but `w3_encode_<TypeName>` doesn't
- Modified `extra/Lamdera/Wire3/Encoder.hs` to check for custom encoders in same-module case
- Shows helpful error message with 3 clear options instead of cryptic "TOO MANY ARGS"

## Testing

Tested by temporarily removing BiSeqDict special-casing and compiling a project that uses BiSeqDict in BackendModel - confirmed new error message appears.

## Related

This improves the developer experience for anyone working with custom opaque types in Lamdera, and will be particularly useful for the upcoming BiSeqDict, MultiSeqDict, and MultiBiSeqDict types in lamdera/containers.