### PR TITLE
Add missing exports in Lamdera.CLI.Login

### DIFF
--- a/extra/Lamdera/CLI/Login.hs
+++ b/extra/Lamdera/CLI/Login.hs
@@ -1,7 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
-module Lamdera.CLI.Login where
+module Lamdera.CLI.Login
+  ( tokenFile
+  , validateCliToken
+  , run
+  )
+  where
 
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID


### PR DESCRIPTION
I was not able to successfully run `distribution/build-macos-arm64.sh` otherwise.

Not sure if this is my fault somehow (I just set up a new computer and tried compiling Lamdera again).