### PR TITLE
lamdera backend --eval improvements

### DIFF
--- a/elm.cabal
+++ b/elm.cabal
@@ -260,6 +260,7 @@ Executable lamdera
         Lamdera.Make
         Lamdera.Nitpick.DebugLog
         Lamdera.Offline
+        Lamdera.Parse.Extra
         Lamdera.PostCompile
         Lamdera.Project
         Lamdera.Relative

--- a/extra/Lamdera/CLI.hs
+++ b/extra/Lamdera/CLI.hs
@@ -216,7 +216,10 @@ backend =
     backendFlags =
       flags Lamdera.CLI.Backend.Flags
         |-- flag "eval" expression "The expression to evaluate (default: `model`)."
-        |-- flag "import" import_ "Additional 'import' statements used when evaluating the expression."
+        |-- flag "import" Lamdera.CLI.Backend.importParser
+              "Additional module imports used when evaluating the expression.\
+              \ For the allowed syntax, see the Lamdera documentation.\
+              \ Examples are 'Dict' or 'Dict, Set as S exposing (size)'."
         |-- onOff "repl" "Start a REPL session instead of evaluating a single expression."
         |-- flag "port" port_ "The port of the `lamdera live` server (default: 8000)."
         |-- onOff "no-colors" "Disable colors in the output. This can help if your terminal uses a non-standard color scheme that makes values hard to read."
@@ -233,17 +236,6 @@ interpreter =
     , _parser = Just
     , _suggest = \_ -> return []
     , _examples = \_ -> return ["node","nodejs"]
-    }
-
-
-import_ :: Parser String
-import_ =
-  Parser
-    { _singular = "import statement"
-    , _plural = "import statements"
-    , _parser = Just
-    , _suggest = \_ -> return []
-    , _examples = \_ -> return ["import Dict","import Set as S"]
     }
 
 

--- a/extra/Lamdera/CLI/Backend.hs
+++ b/extra/Lamdera/CLI/Backend.hs
@@ -185,8 +185,7 @@ runEval :: Env -> Maybe String -> Maybe B.Builder -> IO Exit.ExitCode
 runEval env expr importFlag =
   do  let importState = initialState { _importFlag = importFlag }
           exprInput   = Expr $ BS_UTF8.fromString $ Maybe.fromMaybe "model" expr
-      _ <- eval env importState exprInput
-      return Exit.ExitSuccess
+      outcomeExitCode <$> eval env importState exprInput
 
 
 runRepl :: Env -> IO Exit.ExitCode
@@ -244,8 +243,15 @@ initEnv flags =
 
 
 data Outcome
-  = Loop State
+  = Loop Exit.ExitCode State
   | End Exit.ExitCode
+
+
+outcomeExitCode :: Outcome -> Exit.ExitCode
+outcomeExitCode outcome =
+  case outcome of
+    Loop exitCode _ -> exitCode
+    End exitCode    -> exitCode
 
 
 type M =
@@ -257,7 +263,7 @@ loop env state =
   do  input <- Repl.handleInterrupt (return Skip) read
       outcome <- liftIO (eval env state input)
       case outcome of
-        Loop state ->
+        Loop _ state ->
           do  lift (State.put state)
               loop env state
 
@@ -555,42 +561,52 @@ initialState =
 -- EVAL
 
 
+evalSuccess :: Exit.ExitCode
+evalSuccess =
+  Exit.ExitSuccess
+
+
+evalFailure :: Exit.ExitCode
+evalFailure =
+  Exit.ExitFailure 1
+
+
 eval :: Env -> State -> Input -> IO Outcome
 eval env state@(State imports types decls _) input =
-  Repl.handleInterrupt (putStrLn "<cancelled>" >> return (Loop state)) $
+  Repl.handleInterrupt (putStrLn "<cancelled>" >> return (Loop evalFailure state)) $
   case input of
     Skip ->
-      return (Loop state)
+      return (Loop evalSuccess state)
 
     Exit ->
-      return (End Exit.ExitSuccess)
+      return (End evalSuccess)
 
     Reset ->
       do  putStrLn "<reset>"
-          return (Loop initialState)
+          return (Loop evalSuccess initialState)
 
     Help maybeUnknownCommand ->
       do  putStrLn (toHelpMessage maybeUnknownCommand)
-          return (Loop state)
+          return (Loop evalSuccess state)
 
     Import name src ->
       do  let newState = state { _imports = Map.insert name (B.byteString src) imports }
-          Loop <$> attemptEval env state newState OutputNothing
+          attemptEval env state newState OutputNothing
 
     Type name src ->
       do  let newState = state { _types = Map.insert name (B.byteString src) types }
-          Loop <$> attemptEval env state newState OutputNothing
+          attemptEval env state newState OutputNothing
 
     Port ->
       do  putStrLn "I cannot handle port declarations."
-          return (Loop state)
+          return (Loop evalFailure state)
 
     Decl name src ->
       do  let newState = state { _decls = Map.insert name (B.byteString src) decls }
-          Loop <$> attemptEval env state newState (OutputDecl name)
+          attemptEval env state newState (OutputDecl name)
 
     Expr src ->
-      Loop <$> attemptEval env state state (OutputExpr src)
+      attemptEval env state state (OutputExpr src)
 
 
 
@@ -603,7 +619,7 @@ data Output
   | OutputExpr BS.ByteString
 
 
-attemptEval :: Env -> State -> State -> Output -> IO State
+attemptEval :: Env -> State -> State -> Output -> IO Outcome
 attemptEval (Env root interpreter ansi port) oldState newState output =
   do  result <-
         BW.withScope $ \scope ->
@@ -622,16 +638,16 @@ attemptEval (Env root interpreter ansi port) oldState newState output =
       case result of
         Left exit ->
           do  Exit.toStderr (Exit.replToReport exit)
-              return oldState
+              return $ Loop evalFailure oldState
 
         Right Nothing ->
-          return newState
+          return $ Loop evalSuccess newState
 
         Right (Just javascript) ->
           do  exitCode <- interpret interpreter javascript
               case exitCode of
-                Exit.ExitSuccess   -> return newState
-                Exit.ExitFailure _ -> return oldState
+                Exit.ExitSuccess   -> return $ Loop evalSuccess newState
+                Exit.ExitFailure _ -> return $ Loop evalFailure oldState
 
 
 interpret :: FilePath -> B.Builder -> IO Exit.ExitCode

--- a/extra/Lamdera/CLI/Backend.hs
+++ b/extra/Lamdera/CLI/Backend.hs
@@ -655,10 +655,14 @@ interpret interpreter javascript =
   let
     createProcess = (Proc.proc interpreter []) { Proc.std_in = Proc.CreatePipe }
   in
-  Proc.withCreateProcess createProcess $ \(Just stdin) _ _ handle ->
-    do  B.hPutBuilder stdin javascript
-        IO.hClose stdin
-        Proc.waitForProcess handle
+  Proc.withCreateProcess createProcess $ \mStdin _ _ handle ->
+    case mStdin of
+      Just stdin ->
+        do  B.hPutBuilder stdin javascript
+            IO.hClose stdin
+            Proc.waitForProcess handle
+      Nothing ->
+        error "Pipe to interpreter not available"
 
 
 
@@ -849,7 +853,7 @@ addMatch string isFinished name _ completions =
   let
     suggestion = N.toChars name
   in
-  if List.isPrefixOf string suggestion then
+  if string `List.isPrefixOf` suggestion then
     Repl.Completion suggestion suggestion isFinished : completions
   else
     completions

--- a/extra/Lamdera/CLI/Backend.hs
+++ b/extra/Lamdera/CLI/Backend.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Lamdera.CLI.Backend
   ( Flags(..)
+  , importParser
   , run
   --
   , Lines(..)
@@ -50,6 +51,7 @@ import qualified Elm.Version as V
 import qualified Generate
 import qualified Parse.Expression as PE
 import qualified Parse.Declaration as PD
+import qualified Parse.Keyword as PK
 import qualified Parse.Module as PM
 import qualified Parse.Primitives as P
 import qualified Parse.Space as PS
@@ -66,6 +68,7 @@ import qualified Reporting.Render.Code as Code
 import qualified Reporting.Report as Report
 import qualified Reporting.Task as Task
 import qualified Stuff
+import qualified Terminal
 
 import qualified Sanity
 
@@ -75,21 +78,98 @@ import qualified Json.Decode
 import qualified Json.String
 import qualified Lamdera
 import qualified Lamdera.Http
+import qualified Lamdera.Parse.Extra as Extra
 
 
 
--- RUN
+-- FLAGS
 
 
 data Flags =
   Flags
     { _eval :: Maybe String
-    , _import :: Maybe String
+    , _import :: Maybe B.Builder
     , _repl :: Bool
     , _portFlag :: Maybe Int
     , _noColors :: Bool
     , _interpreterFlag :: Maybe String
     }
+
+
+importParser :: Terminal.Parser B.Builder
+importParser =
+  Terminal.Parser
+    { Terminal._singular = "module imports"
+    , Terminal._plural = "module imports"
+    , Terminal._parser = Just . parseImport
+    , Terminal._suggest = \_ -> return []
+    , Terminal._examples = \_ -> return ["Dict", "Dict, Set as S exposing (size)"]
+    }
+
+
+parseImport :: String -> B.Builder
+parseImport input =
+  parseImportHelp (T.pack input) mempty
+
+
+parseImportHelp :: T.Text -> B.Builder -> B.Builder
+parseImportHelp input output =
+  case T.strip input of
+    ""       -> output
+    stripped -> parseImportHelpStep stripped output
+
+
+parseImportHelpStep :: T.Text -> B.Builder -> B.Builder
+parseImportHelpStep stripped output =
+  let
+    withImport
+      | Extra.startsWith (PV.moduleName (,)) (fromText stripped) = "import " <> stripped
+      | otherwise = stripped
+
+    code =
+      fromText withImport <> "\n"
+
+    result =
+      Extra.fromByteStringWithContext PM.chompImport ES.ImportEnd code
+  in
+  case result of
+    Right (newOutput, _, rest) ->
+      parseImportHelp (toText rest) (output <> B.byteString newOutput)
+
+    Left (newOutput, ES.ImportEnd _ _, rest)
+      | Extra.startsWith (PV.moduleName (,)) rest ->
+          parseImportHelp (addNewline newOutput rest) output
+
+      | Extra.startsWith (PK.import_ (,)) rest ->
+          parseImportHelp (addNewline newOutput rest) output
+
+      | not $ Extra.startsWith (PV.lower (,)) rest ->
+          parseImportHelp (stripDelimiter newOutput rest) output
+
+    Left (newOutput, _, rest) ->
+      output <> B.byteString newOutput <> B.byteString rest
+
+
+stripDelimiter :: BS.ByteString -> BS.ByteString -> T.Text
+stripDelimiter before after =
+  addNewline before (BS.drop 1 after)
+
+
+addNewline :: BS.ByteString -> BS.ByteString -> T.Text
+addNewline before after =
+  T.stripEnd (toText before) <> "\n" <> toText after
+
+
+fromText :: T.Text -> BS.ByteString
+fromText = BS_UTF8.fromString . T.unpack
+
+
+toText :: BS.ByteString -> T.Text
+toText = T.pack . BS_UTF8.toString
+
+
+
+-- RUN
 
 
 run :: () -> Flags -> IO ()
@@ -101,7 +181,7 @@ run () flags =
       Exit.exitWith exitCode
 
 
-runEval :: Env -> Maybe String -> Maybe String -> IO Exit.ExitCode
+runEval :: Env -> Maybe String -> Maybe B.Builder -> IO Exit.ExitCode
 runEval env expr importFlag =
   do  let importState = initialState { _importFlag = importFlag }
           exprInput   = Expr $ BS_UTF8.fromString $ Maybe.fromMaybe "model" expr
@@ -462,7 +542,7 @@ data State =
     { _imports :: Map.Map N.Name B.Builder
     , _types :: Map.Map N.Name B.Builder
     , _decls :: Map.Map N.Name B.Builder
-    , _importFlag :: Maybe String
+    , _importFlag :: Maybe B.Builder
     }
 
 
@@ -575,7 +655,7 @@ toByteString (State imports types decls importFlag) output =
     mconcat
       [ "module ", N.toBuilder N.replModule, " exposing (..)\n"
       , Map.foldr mappend mempty imports
-      , maybe mempty (B.stringUtf8 . (++ "\n")) importFlag
+      , maybe "" (<> "\n") importFlag
       , Map.foldr mappend mempty types
       , Map.foldr mappend mempty decls
       , outputToBuilder output

--- a/extra/Lamdera/Parse/Extra.hs
+++ b/extra/Lamdera/Parse/Extra.hs
@@ -1,0 +1,100 @@
+{-# OPTIONS_GHC -Wall -fno-warn-name-shadowing #-}
+{-# LANGUAGE UnboxedTuples #-}
+module Lamdera.Parse.Extra
+  ( fromByteStringWithContext
+  , startsWith
+  )
+  where
+
+
+import qualified Data.ByteString.Internal as B
+import Data.Either (isRight)
+import Data.Word (Word8)
+import Foreign.Ptr (Ptr, minusPtr, plusPtr)
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
+
+import qualified Parse.Primitives as P
+
+
+fromByteStringWithContext :: P.Parser x a -> (P.Row -> P.Col -> x) -> B.ByteString -> Either (B.ByteString, x, B.ByteString) (B.ByteString, a, B.ByteString)
+fromByteStringWithContext parser toEnd src =
+  let
+    parserWithContext =
+      do  value <- specializeAtPos (specializer src) parser
+          withContext src value <$> getOffset
+
+    toEndWithContext row col =
+      specializer src (toEnd row col) row col
+  in
+  fromByteStringIgnoringRest parserWithContext toEndWithContext src
+
+
+specializeAtPos :: (x -> P.Row -> P.Col -> y) -> P.Parser x a -> P.Parser y a
+specializeAtPos addContext (P.Parser parser) =
+  P.Parser $ \state cok eok cerr eerr ->
+    let
+      cerr' r c tx = cerr r c (addContext (tx r c))
+      eerr' r c tx = eerr r c (addContext (tx r c))
+    in
+    parser state cok eok cerr' eerr'
+
+
+specializer :: B.ByteString -> value -> P.Row -> P.Col -> (B.ByteString, value, B.ByteString)
+specializer src value row col =
+  withContext src value
+    $ either id id
+    $ fromByteStringIgnoringRest (toOffset row col) (\_ _ -> 0) src
+
+
+withContext :: B.ByteString -> value -> Int -> (B.ByteString, value, B.ByteString)
+withContext (B.PS fptr _ length) value offset =
+  (B.fromForeignPtr fptr 0 offset, value, B.fromForeignPtr fptr offset (length - offset))
+
+
+getOffset :: P.Parser x Int
+getOffset =
+  P.Parser $ \state@(P.State src pos _ _ _ _) _ eok _ _ ->
+    eok (minusPtr pos (unsafeForeignPtrToPtr src)) state
+
+
+toOffset :: P.Row -> P.Col -> P.Parser x Int
+toOffset targetRow targetCol =
+  P.Parser $ \(P.State src pos end indent row col) cok _ _ _ ->
+    let
+      (# newPos, newRow, newCol #) = moveTo targetRow targetCol pos end row col
+    in
+    cok (minusPtr newPos (unsafeForeignPtrToPtr src)) (P.State src newPos end indent newRow newCol)
+
+
+moveTo :: P.Row -> P.Col -> Ptr Word8 -> Ptr Word8 -> P.Row -> P.Col -> (# Ptr Word8, P.Row, P.Col #)
+moveTo targetRow targetCol pos end row col =
+  if pos >= end || row > targetRow || row == targetRow && col >= targetCol then
+    (# pos, row, col #)
+
+  else
+    case P.unsafeIndex pos of
+      0x0A {- \n -} ->
+        moveTo targetRow targetCol (plusPtr pos 1) end (row + 1) 1
+
+      _ ->
+        moveTo targetRow targetCol (plusPtr pos 1) end row (col + 1)
+
+
+startsWith :: P.Parser x a -> B.ByteString -> Bool
+startsWith parser =
+  isRight . fromByteStringIgnoringRest (P.specialize (\_ _ _ -> ()) parser) (\_ _ -> ())
+
+
+fromByteStringIgnoringRest :: P.Parser x a -> (P.Row -> P.Col -> x) -> B.ByteString -> Either x a
+fromByteStringIgnoringRest = P.fromByteString . stopAfter
+
+
+stopAfter :: P.Parser x a -> P.Parser x a
+stopAfter = (<* ignoreRest)
+
+
+ignoreRest :: P.Parser x ()
+ignoreRest =
+  P.Parser $ \(P.State src pos _ indent row col) _ eok _ _ ->
+    -- set end to current pos to avoid errors in P.fromByteString when pos is not at the end of input
+    eok () (P.State src pos pos indent row col)


### PR DESCRIPTION
Improvements to the `lamdera backend --eval` command:

- Greatly improved `--import` parser. Examples for allowed syntax:
  - `--import 'Dict'`
  - `--import 'Dict as D'`
  - `--import 'Dict as D exposing (size)'`
  - `--import 'Dict, Set as S exposing (empty)'`
  - `--import 'Dict / Set / Task / '`

  The previous syntax is still allowed, too:
  - `--import 'import Dict'`

- The exit code of the `lamdera backend --eval` command indicates whether the expression was successfully evaluated or not.