### PR TITLE
Fix devbar z-index to ensure it stays above app content

### DIFF
--- a/extra/LocalDev/runtime-src/Lamdera/Live.elm
+++ b/extra/LocalDev/runtime-src/Lamdera/Live.elm
@@ -1187,6 +1187,7 @@ lamderaPane devbar nodeType =
         [ style "font-family" "system-ui, Helvetica Neue, sans-serif"
         , style "font-size" "12px"
         , style "position" "fixed"
+        , style "z-index" "100000"
         , xForLocation devbar.location
         , yForLocation devbar.location
         , style "color" white

--- a/extra/LocalDev/runtime-src/Lamdera/Live.elm
+++ b/extra/LocalDev/runtime-src/Lamdera/Live.elm
@@ -1187,7 +1187,7 @@ lamderaPane devbar nodeType =
         [ style "font-family" "system-ui, Helvetica Neue, sans-serif"
         , style "font-size" "12px"
         , style "position" "fixed"
-        , style "z-index" "100000"
+        , style "z-index" "2147483647"
         , xForLocation devbar.location
         , yForLocation devbar.location
         , style "color" white


### PR DESCRIPTION
## Summary
- Set z-index to 100000 on the devbar pane so it doesn't get hidden behind app elements with higher z-index values

## Test plan
- Run `lamdera live` with an app that has elements with high z-index
- Verify the devbar stays visible above all app content