### PR TITLE
Add `--open` flag for `lamdera live`

### DIFF
--- a/extra/Lamdera/CLI.hs
+++ b/extra/Lamdera/CLI.hs
@@ -38,6 +38,7 @@ live =
     liveFlags =
       flags Develop.Flags
         |-- flag "port" port_ "The port of the server (default: 8000)"
+        |-- onOff "open" "Open a web browser to view the local server"
   in
   Terminal.Command "live" (Common summary) details example noArgs liveFlags Develop.run
 

--- a/terminal/src/Develop.hs
+++ b/terminal/src/Develop.hs
@@ -48,7 +48,7 @@ import qualified Lamdera.TypeHash
 import qualified Lamdera.PostCompile
 
 import qualified Data.List as List
-import Ext.Common (trackedForkIO, whenDebug)
+import Ext.Common (trackedForkIO, whenDebug, stringToText)
 import qualified Ext.Filewatch as Filewatch
 import qualified Ext.Sentry as Sentry
 import Control.Concurrent.STM (atomically, newTVarIO, readTVar, writeTVar, TVar)
@@ -61,6 +61,7 @@ import StandaloneInstances
 data Flags =
   Flags
     { _port :: Maybe Int
+    , _open :: Bool
     }
 
 
@@ -72,7 +73,7 @@ run () flags = do
 
 
 runWithRoot :: FilePath -> Flags -> IO ()
-runWithRoot root (Flags maybePort) =
+runWithRoot root (Flags maybePort shouldOpenBrowser) =
   do
       Lamdera.setLiveMode True
       let port = maybe 8000 id maybePort
@@ -121,6 +122,8 @@ runWithRoot root (Flags maybePort) =
           Filewatch.watchFile override recompile
 
       Lamdera.ReverseProxy.start
+
+      onlyWhen shouldOpenBrowser $ systemOpenPath $ stringToText $ "http://localhost:" ++ show port
 
       Live.withEnd liveState $
        httpServe (config port) $ gcatchlog "general" $

--- a/terminal/src/Main.hs
+++ b/terminal/src/Main.hs
@@ -168,7 +168,7 @@ reactor =
         \ the refresh button in the browser to recompile things."
 
     reactorFlags =
-      flags Develop.Flags
+      flags (\port -> Develop.Flags port False)
         |-- flag "port" port_ "The port of the server (default: 8000)"
   in
   Terminal.Command "reactor" (Common summary) details example noArgs reactorFlags Develop.run

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -126,7 +126,7 @@ liveReloadLive = do
   setEnv "LDEBUG" "1"
   setEnv "EXPERIMENTAL" "1"
   let p = "test/scenario-alltypes"
-  trackedForkIO "Test.liveReloadLive" $ Develop.runWithRoot p (Develop.Flags Nothing)
+  trackedForkIO "Test.liveReloadLive" $ Develop.runWithRoot p (Develop.Flags Nothing False)
 
   -- Doing this actually makes no sense in the :rr context, as the thread is long-running so it's the same as
   -- disabling the ENV vars mid-run! But leaving it here as a reminder, because it _does_ pollute the ENV


### PR DESCRIPTION
**Quick Summary:** Add an `--open` flag to `lamdera live`. When this flag is set, `lamdera live` will open a web browser window to `localhost:[port]` when the local development server starts up.


## SSCCE

```bash
$ lamdera live --open
```


## Additional Details

I discussed briefly with Mario and he said he'd be open to including this feature. I don't really know Haskell, but it seemed like a simple change so I've had a go at implementing it. If there are reasons why this might not work or might cause problems, please feel free to ignore or reject this PR without further thought! It's not an important feature at all, just a minor convenience.

As far as I can see, we already have the machinery needed to open a web browser window in a cross-platform way: `systemOpenPath` in `extra/Lamdera.hs`, which is used by the `lamdera login` command. So we can reuse this for the `--open` flag.

`--open` seems to be a relatively common name for a flag that opens a web browser - it exists in `elm-live` and `vite`, for example, and `http-server` has `-o`.

I am not sure if I have adequately minimized changes to the original Elm compiler code - happy to get feedback on this and refactor to make it neater if you have suggestions.

I am also not sure if I've put the call to `systemOpenPath` in the optimal place in the sequence of operations in the `runWithRoot` function in `terminal/Develop.hs`. I figure we want to do it as late as possible to ensure that the server has booted up before we open the browser window. Maybe it should come after the `Live.withEnd ...` section, but I wasn't sure what the `<|>` operators do and I was concerned that I might mess something up if I put it right at the end of the function.