### PR TITLE
Fix wire encoder+decoder for type aliases with extensible records thr…

### DIFF
--- a/extra/Lamdera/Wire3/Decoder.hs
+++ b/extra/Lamdera/Wire3/Decoder.hs
@@ -416,7 +416,14 @@ decoderForType ifaces cname tipe =
                      let extendedRecord = TRecord resolved Nothing & resolveTvar tvars_
                      in decoderForType ifaces cname extendedRecord
                     Nothing -> normalDecoder
-                otherTypes -> normalDecoder
+                _ ->
+                  -- Resolve extensible records through TAlias chains,
+                  -- e.g. Color = ColorValue { red, green, blue, alpha }
+                  case resolveTvar tvars_ tipe of
+                    TAlias _ _ _ (Filled (TRecord fieldMap Nothing)) ->
+                      let fields = fieldMap & fieldsToList & List.sortOn (\(name, field) -> name)
+                      in decodeRecord ifaces cname fields
+                    _ -> normalDecoder
             Filled tipe ->
               case tipe of
                 TRecord fieldMap extensibleName ->

--- a/extra/Lamdera/Wire3/Encoder.hs
+++ b/extra/Lamdera/Wire3/Encoder.hs
@@ -365,7 +365,14 @@ inlineIfRecordOrCall depth ifaces cname tipe tvars aType =
               in deepEncoderForType depth ifaces cname extendedRecord
             Nothing -> normalEncoder
 
-        otherTypes -> normalEncoder
+        _ ->
+          -- Resolve extensible records through TAlias chains,
+          -- e.g. Color = ColorValue { red, green, blue, alpha }
+          case resolveTvar tvars tipe of
+            TAlias _ _ _ (Filled (TRecord fieldMap Nothing)) ->
+              let extendedRecord = TRecord fieldMap Nothing
+              in deepEncoderForType depth ifaces cname extendedRecord
+            _ -> normalEncoder
     Filled _ -> normalEncoder
 
 {-| Called for encoding tvar type values, i.e.

--- a/extra/Lamdera/Wire3/Encoder.hs
+++ b/extra/Lamdera/Wire3/Encoder.hs
@@ -369,9 +369,8 @@ inlineIfRecordOrCall depth ifaces cname tipe tvars aType =
           -- Resolve extensible records through TAlias chains,
           -- e.g. Color = ColorValue { red, green, blue, alpha }
           case resolveTvar tvars tipe of
-            TAlias _ _ _ (Filled (TRecord fieldMap Nothing)) ->
-              let extendedRecord = TRecord fieldMap Nothing
-              in deepEncoderForType depth ifaces cname extendedRecord
+            TAlias _ _ _ (Filled extendedRecord@(TRecord _ Nothing)) ->
+              deepEncoderForType depth ifaces cname extendedRecord
             _ -> normalEncoder
     Filled _ -> normalEncoder
 

--- a/test/Test/Wire.hs
+++ b/test/Test/Wire.hs
@@ -130,6 +130,7 @@ wire = do
             , "src/Test/Wire_Tvar_Recursive_Reference.elm"
             , "src/Test/Wire_Unsupported.elm"
             , "src/Test/Wire_Unconstructable.elm"
+            , "src/Test/Wire_Union_ForeignRecordAlias.elm"
             ]
 
       let

--- a/test/scenario-alltypes/src/Test/External.elm
+++ b/test/scenario-alltypes/src/Test/External.elm
@@ -30,6 +30,14 @@ type alias SubSubRecordAlias threadedTvar =
     }
 
 
+type alias ExternalExtensibleBase compatible =
+    { compatible | base : String }
+
+
+type alias ExternalRecordViaExtensible =
+    ExternalExtensibleBase { red : Int, green : Int }
+
+
 expected_w3_encode_ExternalRecordBasic : ExternalRecordBasic -> Lamdera.Wire3.Encoder
 expected_w3_encode_ExternalRecordBasic =
     \w3_rec_var0 -> Lamdera.Wire3.encodeSequenceWithoutLength [ Lamdera.Wire3.encodeInt w3_rec_var0.int ]
@@ -113,3 +121,30 @@ expected_w3_decode_ExternalCustomThreaded w3_x_c_threadedTvar w3_x_c_threadedTva
                     _ ->
                         Lamdera.Wire3.failDecode
             )
+
+
+expected_w3_encode_ExternalExtensibleBase : ({ compatible | base : String.String } -> Lamdera.Wire3.Encoder) -> ExternalExtensibleBase compatible -> Lamdera.Wire3.Encoder
+expected_w3_encode_ExternalExtensibleBase w3_x_c_compatible =
+    w3_x_c_compatible
+
+
+expected_w3_decode_ExternalExtensibleBase w3_x_c_compatible =
+    w3_x_c_compatible
+
+
+expected_w3_encode_ExternalRecordViaExtensible : ExternalRecordViaExtensible -> Lamdera.Wire3.Encoder
+expected_w3_encode_ExternalRecordViaExtensible =
+    \w3_rec_var0 ->
+        Lamdera.Wire3.encodeSequenceWithoutLength
+            [ Lamdera.Wire3.encodeString w3_rec_var0.base
+            , Lamdera.Wire3.encodeInt w3_rec_var0.green
+            , Lamdera.Wire3.encodeInt w3_rec_var0.red
+            ]
+
+
+expected_w3_decode_ExternalRecordViaExtensible =
+    Lamdera.Wire3.succeedDecode
+        (\base0 green0 red0 -> { base = base0, green = green0, red = red0 })
+        |> Lamdera.Wire3.andMapDecode Lamdera.Wire3.decodeString
+        |> Lamdera.Wire3.andMapDecode Lamdera.Wire3.decodeInt
+        |> Lamdera.Wire3.andMapDecode Lamdera.Wire3.decodeInt

--- a/test/scenario-alltypes/src/Test/Wire_Union_ForeignRecordAlias.elm
+++ b/test/scenario-alltypes/src/Test/Wire_Union_ForeignRecordAlias.elm
@@ -1,0 +1,85 @@
+module Test.Wire_Union_ForeignRecordAlias exposing (..)
+
+import Bytes.Decode
+import Bytes.Encode
+import Lamdera.Wire3
+import Test.External exposing (ExternalRecordBasic, ExternalRecordViaExtensible)
+
+
+{-| Regression test: extensible record aliases through alias chains.
+See: <https://github.com/elm-explorations/test/pull/249#issuecomment-4076937757>
+-}
+type WrapsBasicRecord
+    = WrapsBasicRecord ExternalRecordBasic
+
+
+type WrapsExtensibleRecord
+    = WrapsExtensibleRecord ExternalRecordViaExtensible
+
+
+type WrapsInRecord
+    = WrapsInRecord { field : ExternalRecordViaExtensible }
+
+
+expected_w3_encode_WrapsBasicRecord : WrapsBasicRecord -> Lamdera.Wire3.Encoder
+expected_w3_encode_WrapsBasicRecord w3v =
+    case w3v of
+        WrapsBasicRecord v0 ->
+            Lamdera.Wire3.encodeSequenceWithoutLength [ Bytes.Encode.unsignedInt8 0, Test.External.w3_encode_ExternalRecordBasic v0 ]
+
+
+expected_w3_decode_WrapsBasicRecord =
+    Bytes.Decode.unsignedInt8
+        |> Lamdera.Wire3.andThenDecode
+            (\w3v ->
+                case w3v of
+                    0 ->
+                        Lamdera.Wire3.succeedDecode WrapsBasicRecord |> Lamdera.Wire3.andMapDecode Test.External.w3_decode_ExternalRecordBasic
+
+                    _ ->
+                        Lamdera.Wire3.failDecode
+            )
+
+
+expected_w3_encode_WrapsExtensibleRecord : WrapsExtensibleRecord -> Lamdera.Wire3.Encoder
+expected_w3_encode_WrapsExtensibleRecord w3v =
+    case w3v of
+        WrapsExtensibleRecord v0 ->
+            Lamdera.Wire3.encodeSequenceWithoutLength [ Bytes.Encode.unsignedInt8 0, Test.External.w3_encode_ExternalRecordViaExtensible v0 ]
+
+
+expected_w3_decode_WrapsExtensibleRecord =
+    Bytes.Decode.unsignedInt8
+        |> Lamdera.Wire3.andThenDecode
+            (\w3v ->
+                case w3v of
+                    0 ->
+                        Lamdera.Wire3.succeedDecode WrapsExtensibleRecord |> Lamdera.Wire3.andMapDecode Test.External.w3_decode_ExternalRecordViaExtensible
+
+                    _ ->
+                        Lamdera.Wire3.failDecode
+            )
+
+
+expected_w3_encode_WrapsInRecord : WrapsInRecord -> Lamdera.Wire3.Encoder
+expected_w3_encode_WrapsInRecord w3v =
+    case w3v of
+        WrapsInRecord v0 ->
+            Lamdera.Wire3.encodeSequenceWithoutLength [ Bytes.Encode.unsignedInt8 0, Test.External.w3_encode_ExternalRecordViaExtensible v0.field ]
+
+
+expected_w3_decode_WrapsInRecord =
+    Bytes.Decode.unsignedInt8
+        |> Lamdera.Wire3.andThenDecode
+            (\w3v ->
+                case w3v of
+                    0 ->
+                        Lamdera.Wire3.succeedDecode WrapsInRecord
+                            |> Lamdera.Wire3.andMapDecode
+                                (Lamdera.Wire3.succeedDecode (\field0 -> { field = field0 })
+                                    |> Lamdera.Wire3.andMapDecode Test.External.w3_decode_ExternalRecordViaExtensible
+                                )
+
+                    _ ->
+                        Lamdera.Wire3.failDecode
+            )


### PR DESCRIPTION
Hey @supermario! I ran into an issue, reported in [elm-explorations/test#249 (comment)](https://github.com/elm-explorations/test/pull/249#issuecomment-4076937757) by @micahhahn, who hit this using `elm-snapshot` (via `elm-pages run` → `lamdera make`) with a codebase using `rtfeldman/elm-css`. The salient point being that `elm-pages` scripts use `lamdera make` under the hood, and having a type definition with this particular shape caused a compiler error because of incorrect wire codegen.

## The Problem

When a type alias references an extensible record alias through a chain of aliases (e.g., `Css.Color = ColorValue { red, green, blue, alpha }` where `ColorValue compatible = { compatible | value : String, color : Compatible }`), the wire encoder and decoder only handle the extension fields (4 fields), losing the base fields from the extensible record (should be 6 fields).

This causes a compiler error when any custom type wraps such a type alias:

```elm
type Theme = Theme { primary : Css.Color }
-- TYPE MISMATCH: Css.Color vs { alpha : Float, blue : Int, green : Int, red : Int }
```

## Root cause

In both `decoderForType` (Decoder.hs) and `inlineIfRecordOrCall` (Encoder.hs), the `TAlias` case's `Holey` branch checks for a direct `TRecord` inner type to resolve extensible records via `resolvedRecordFieldMapM`. But when the inner type is another `TAlias` layer (common with packages like `elm-css` that define aliases through multiple modules), the check doesn't fire and falls to `normalDecoder`/`normalEncoder`. This generates `w3_decode_Color = w3_decode_ColorValue (decodeRecord {alpha, blue, green, red})`, but since `w3_decode_ColorValue` just delegates to its argument, the result only handles 4 of 6 fields. Same for the encoder.

## Fix

In the `Holey` branch's fallthrough case for both encoder and decoder, use `resolveTvar` to resolve through alias chains.

## Reproducing In Tests

Here's what I was able to test:

- Added a test fixture in `test/scenario-alltypes/src/Test/Wire_Union_ForeignRecordAlias.elm` with custom types wrapping foreign extensible record aliases (mirrors the `Css.Color` pattern)
- Reproduced the error with `lamdera make` on a project using `rtfeldman/elm-css`, and confirmed red→green by building a patched `lamdera` from source with `stack build`
- Beyond just compilation, I also verified runtime encode -> decode roundtrips across 12 test cases (`Css.Color`, `Css.Px`, `Maybe Css.Color`, `List Css.Color`, custom types with multiple variants, nested records, etc.) and confirmed that field values roundtrip correctly. That test case isn't checked in, I couldn't find a good place for that to live within the codebase, could be a good thing to explore in the future to have automated encoder/decoder roundtrip runs

The one thing I wasn't able to run locally was the full wire test suite `Test.Wire.all`, maybe you could try running that in your environment as a sanity check?

Let me know if you have any feedback on this, happy to make any changes or discuss!
