### PR TITLE
Report a clear error when lamdera/codecs is missing from elm.json

### DIFF
--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -962,6 +962,7 @@ data Outline
   | OutlineNoAppCore
   | OutlineNoAppJson
   | OutlineLamderaMissingDeps
+  | OutlineLamderaMissingCodecs
   | OutlineLamderaReplacementPackageVersionTooLow Pkg.Name V.Version V.Version
   | OutlineLamderaReplacementPackageVersionTooHigh Pkg.Name V.Version V.Version
 
@@ -1062,6 +1063,13 @@ toOutlineReport problem =
         [ D.reflow "You can install it with:"
         , D.indent 4 $ D.green $ "lamdera install lamdera/core"
         , D.reflow "Note: if you're trying to run a normal Elm app, use the elm binary instead."
+        ]
+
+    OutlineLamderaMissingCodecs ->
+      Help.report "MISSING DEPENDENCY" (Just "elm.json")
+        "A Lamdera application must have \"lamdera/codecs\" as a dependency."
+        [ D.reflow "Wire code generation relies on this package. You can install it with:"
+        , D.indent 4 $ D.green $ "lamdera install lamdera/codecs"
         ]
 
     OutlineLamderaReplacementPackageVersionTooLow name replacedVersion elmJsonVersion ->

--- a/compiler/src/Generate/JavaScript.hs
+++ b/compiler/src/Generate/JavaScript.hs
@@ -12,7 +12,6 @@ import Prelude hiding (cycle, print)
 import qualified Data.ByteString.Builder as B
 import Data.Monoid ((<>))
 import qualified Data.List as List
-import Data.Map ((!))
 import qualified Data.Map as Map
 import qualified Data.Name as Name
 import qualified Data.Set as Set
@@ -23,6 +22,7 @@ import qualified AST.Optimized as Opt
 import qualified Data.Index as Index
 import qualified Elm.Kernel as K
 import qualified Elm.ModuleName as ModuleName
+import qualified Elm.Package as Pkg
 import qualified Generate.JavaScript.Builder as JS
 import qualified Generate.JavaScript.Expression as Expr
 import qualified Generate.JavaScript.Functions as Functions
@@ -194,10 +194,10 @@ addGlobalHelp mode graph global state =
   let
     addDeps deps someState =
       Set.foldl' (addGlobal mode graph) someState deps
-    
+
     argLookup = makeArgLookup graph
   in
-  case graph ! global of
+  case Map.findWithDefault (error $ globalNotFound global) global graph of
     -- @LAMDERA
     Opt.Define (Opt.Function args body) deps
       | length args > 1 ->
@@ -715,4 +715,13 @@ toMainEsmExports mode mains =
     exports = generateExports mode (Map.foldrWithKey addToTrie emptyTrie mains)
   in
   "export const Elm = " <> exports <> ";"
+
+
+globalNotFound :: Opt.Global -> String
+globalNotFound (Opt.Global (ModuleName.Canonical pkg modul) name) =
+  "Global not found in dependency graph: "
+  ++ Pkg.toChars pkg ++ ":" ++ Name.toChars modul ++ "." ++ Name.toChars name
+  ++ "\n    This likely means a required package is missing from elm.json."
+  ++ "\n    If you are using the Lamdera compiler, make sure lamdera/codecs is installed:"
+  ++ "\n        lamdera install lamdera/codecs"
 

--- a/extra/Lamdera/Checks.hs
+++ b/extra/Lamdera/Checks.hs
@@ -42,10 +42,14 @@ runChecks root shouldCheckLamdera direct indirect default_ = do
       return $ Left err
 
     Right () ->
+      let allDeps = Map.union direct indirect in
       if Map.member Pkg.lamderaCore direct
-        then do
-          onlyWhen shouldCheckLamdera (Lamdera.Checks.runChecks_ root)
-          default_
+        then
+          if not (Map.member Pkg.lamderaCodecs allDeps)
+            then return $ Left Exit.OutlineLamderaMissingCodecs
+            else do
+              onlyWhen shouldCheckLamdera (Lamdera.Checks.runChecks_ root)
+              default_
         else
           if shouldCheckLamdera
             then return $ Left Exit.OutlineLamderaMissingDeps

--- a/extra/Lamdera/Checks.hs
+++ b/extra/Lamdera/Checks.hs
@@ -45,11 +45,14 @@ runChecks root shouldCheckLamdera direct indirect default_ = do
       let allDeps = Map.union direct indirect in
       if Map.member Pkg.lamderaCore direct
         then
-          if not (Map.member Pkg.lamderaCodecs allDeps)
-            then return $ Left Exit.OutlineLamderaMissingCodecs
-            else do
-              onlyWhen shouldCheckLamdera (Lamdera.Checks.runChecks_ root)
-              default_
+          if shouldCheckLamdera
+            then
+              if not (Map.member Pkg.lamderaCodecs allDeps)
+                then return $ Left Exit.OutlineLamderaMissingCodecs
+                else do
+                  Lamdera.Checks.runChecks_ root
+                  default_
+            else default_
         else
           if shouldCheckLamdera
             then return $ Left Exit.OutlineLamderaMissingDeps


### PR DESCRIPTION
The early dependency check only verified lamdera/core was present, so projects missing lamdera/codecs (e.g. elm-pages) hit an opaque Map.! crash during JS codegen.  Now Checks.hs also validates that lamdera/codecs is reachable, and the graph lookup in JavaScript.hs uses Map.findWithDefault to produce a descriptive message naming the
exact missing global.  Fixes #59.
