### PR TITLE
  Use identity/value for Bytes port encoding instead of lamdera/codecs

### DIFF
--- a/compiler/src/Optimize/Port.hs
+++ b/compiler/src/Optimize/Port.hs
@@ -51,7 +51,7 @@ toEncoder tipe =
           | name == Name.bool   -> encode "bool"
           | name == Name.string -> encode "string"
           | name == Name.value  -> Names.registerGlobal ModuleName.basics Name.identity
-          | name == Name.bytes  -> Names.registerGlobal ModuleName.lamderaWire3 "encodeBytes_"
+          | name == Name.bytes  -> Names.registerGlobal ModuleName.basics Name.identity
 
         [arg]
           | name == Name.maybe -> encodeMaybe arg
@@ -180,7 +180,7 @@ toDecoder tipe =
           | name == Name.bool   -> decode "bool"
           | name == Name.string -> decode "string"
           | name == Name.value  -> decode "value"
-          | name == Name.bytes  -> Names.registerGlobal ModuleName.lamderaWire3 "decodeBytes_"
+          | name == Name.bytes  -> decode "value"
 
         [arg]
           | name == Name.maybe -> decodeMaybe arg


### PR DESCRIPTION
The Bytes encoder and decoder for ports and flags referenced encodeBytes_/decodeBytes_ from lamdera/codecs, which crashes with Map.! when that package is absent.  Since Bytes is a raw DataView in JS, no transformation is needed at the boundary: use Basics.identity for encoding and Json.Decode.value for decoding, matching how Json.Encode.Value is already handled.  Fixes #26.
