### PR TITLE
  Allow configuring <html lang> via html-lang file

### DIFF
--- a/compiler/src/Generate/Html.hs
+++ b/compiler/src/Generate/Html.hs
@@ -71,9 +71,12 @@ sandwich_ root moduleName javascript =
           customHead
         else
           "<title>" <> name <> "</title>"
+
+    htmlTag = Lamdera.unsafe $ Lamdera.Live.lamderaHtmlLang root
   in
-  [r|<!DOCTYPE HTML>
-<html>
+  "<!DOCTYPE HTML>\n"
+  <> htmlTag
+  <> [r|
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0">

--- a/extra/Lamdera/Live.hs
+++ b/extra/Lamdera/Live.hs
@@ -64,6 +64,18 @@ lamderaLiveHead root = do
       pure (False, "")
 
 
+lamderaHtmlLang :: FilePath -> IO B.Builder
+lamderaHtmlLang root = do
+  langM <- readUtf8Text $ root </> "html-lang"
+  pure $ maybe "<html>" toHtmlTag langM
+  where
+    toHtmlTag lang =
+      let trimmed = T.strip lang in
+      if T.null trimmed
+        then "<html>"
+        else "<html lang=\"" <> T.encodeUtf8Builder trimmed <> "\">"
+
+
 lamderaLive :: BS.ByteString
 lamderaLive =
   $(bsToExp =<< runIO (Lamdera.Relative.readByteString "extra/dist/live.js"))

--- a/extra/Lamdera/Live.hs
+++ b/extra/Lamdera/Live.hs
@@ -6,7 +6,8 @@ module Lamdera.Live where
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as B
-import qualified Data.Text.Encoding as T
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified System.Directory as Dir
 import System.FilePath as FP
 import Control.Exception (finally, throw)
@@ -40,16 +41,16 @@ lamderaLiveSrc =
             overrideM <- readUtf8Text overridePathBuilt
             case overrideM of
               Just override -> do
-                pure (T.encodeUtf8Builder override)
+                pure (TE.encodeUtf8Builder override)
               Nothing -> do
                 Lamdera.debug $ "Couldn't load override " ++ overridePath ++ ", using compiled lamderaLive"
-                pure (T.encodeUtf8Builder (T.decodeUtf8 lamderaLive))
+                pure (TE.encodeUtf8Builder (TE.decodeUtf8 lamderaLive))
           else do
             Lamdera.debug $ "Couldn't find override " ++ overridePath ++ ", using compiled lamderaLive"
-            pure (T.encodeUtf8Builder (T.decodeUtf8 lamderaLive))
+            pure (TE.encodeUtf8Builder (TE.decodeUtf8 lamderaLive))
       else do
         Lamdera.debug $ "🗿  Using compiled lamderaLive"
-        pure (T.encodeUtf8Builder (T.decodeUtf8 lamderaLive))
+        pure (TE.encodeUtf8Builder (TE.decodeUtf8 lamderaLive))
 
 
 -- @TODO means we have to restart live for any changes... how to improve that?
@@ -58,7 +59,7 @@ lamderaLiveHead root = do
   headHtmlM <- readUtf8Text $ root </> "head.html"
   case headHtmlM of
     Just headHtml ->
-      pure (True, T.encodeUtf8Builder headHtml)
+      pure (True, TE.encodeUtf8Builder headHtml)
 
     Nothing ->
       pure (False, "")
@@ -73,7 +74,14 @@ lamderaHtmlLang root = do
       let trimmed = T.strip lang in
       if T.null trimmed
         then "<html>"
-        else "<html lang=\"" <> T.encodeUtf8Builder trimmed <> "\">"
+        else "<html lang=\"" <> TE.encodeUtf8Builder (escapeHtmlAttr trimmed) <> "\">"
+
+    escapeHtmlAttr = T.concatMap $ \c -> case c of
+      '&'  -> "&amp;"
+      '"'  -> "&quot;"
+      '<'  -> "&lt;"
+      '>'  -> "&gt;"
+      _    -> T.singleton c
 
 
 lamderaLive :: BS.ByteString


### PR DESCRIPTION
Read an optional html-lang file from the project root to set the lang attribute on the generated <html> tag.  If the file contains e.g. "fr", the output becomes <html lang="fr">.  If absent or empty, the tag is plain <html> as before.  Fixes #84.
