### PR TITLE
  Add --only-preserve-backend flag to lamdera check

### DIFF
--- a/extra/Lamdera/CLI.hs
+++ b/extra/Lamdera/CLI.hs
@@ -90,6 +90,7 @@ check =
       flags Lamdera.CLI.Check.Flags
         |-- onOff "destructive-migration" "Generate a migration that will drop all production data when deployed, instead of the usual automatic migration generation."
         |-- onOff "force" "Force a production check for Evergreen, even if we're on a non main/master branch (i.e. a preview). You shouldn't be using this unless you know what you're doing."
+        |-- onOff "only-preserve-backend" "Generate migrations that only preserve the BackendModel; all other types use ModelUnchanged/MsgUnchanged."
   in
   Terminal.Command "check" (Common summary) details example noArgs checkFlags Lamdera.CLI.Check.run
 

--- a/extra/Lamdera/CLI/Check.hs
+++ b/extra/Lamdera/CLI/Check.hs
@@ -59,15 +59,16 @@ data Flags =
   Flags
     { _destructiveMigration :: Bool
     , _force :: Bool
+    , _onlyPreserveBackend :: Bool
     }
 
 
 run_ :: IO ()
-run_ = run () (Lamdera.CLI.Check.Flags { _destructiveMigration = False, _force = False })
+run_ = run () (Lamdera.CLI.Check.Flags { _destructiveMigration = False, _force = False, _onlyPreserveBackend = False })
 
 
 run :: () -> Lamdera.CLI.Check.Flags -> IO ()
-run () flags@(Lamdera.CLI.Check.Flags destructiveMigration force) = do
+run () flags@(Lamdera.CLI.Check.Flags destructiveMigration force onlyPreserveBackend) = do
   debug_ "Starting check..."
 
   inProduction_ <- Lamdera.inProduction
@@ -93,7 +94,7 @@ run () flags@(Lamdera.CLI.Check.Flags destructiveMigration force) = do
 
 
 runHelp :: () -> Lamdera.CLI.Check.Flags -> IO ()
-runHelp () flags@(Lamdera.CLI.Check.Flags destructiveMigration force) = do
+runHelp () flags@(Lamdera.CLI.Check.Flags destructiveMigration force onlyPreserveBackend) = do
   Lamdera.setCheckMode True
 
   -- appNameEnvM <- Env.lookupEnv "LAMDERA_APP_NAME"
@@ -320,7 +321,7 @@ onlineCheck root appName inDebug localTypes externalTypeWarnings isHoistRebuild 
                       then
                         Lamdera.Evergreen.MigrationDestructive.generate lastLocalTypeChangeVersion nextVersion typeCompares
                       else
-                        Lamdera.Evergreen.MigrationGenerator.betweenVersions typeCompares lastLocalTypeChangeVersion nextVersion root
+                        Lamdera.Evergreen.MigrationGenerator.betweenVersions onlyPreserveBackend typeCompares lastLocalTypeChangeVersion nextVersion root
                   writeUtf8 nextMigrationPath defaultMigrations
 
                   Progress.throw $

--- a/extra/Lamdera/Evergreen/MigrationGenerator.hs
+++ b/extra/Lamdera/Evergreen/MigrationGenerator.hs
@@ -33,8 +33,8 @@ import qualified Lamdera.Wire3.Helpers
 import Lamdera.Evergreen.MigrationGeneratorHelpers
 import Lamdera.Evergreen.MigrationSpecialCases
 
-betweenVersions :: CoreTypeDiffs -> Int -> Int -> String -> IO Text
-betweenVersions coreTypeDiffs oldVersion newVersion root = do
+betweenVersions :: Bool -> CoreTypeDiffs -> Int -> Int -> String -> IO Text
+betweenVersions onlyPreserveBackend coreTypeDiffs oldVersion newVersion root = do
     let
         paths = NE.List ("src/Evergreen/V" <> show oldVersion <> "/Types.elm") ["src/Evergreen/V" <> show newVersion <> "/Types.elm"]
         moduleNameString = "Evergreen.V" <> show newVersion <> ".Types"
@@ -46,26 +46,29 @@ betweenVersions coreTypeDiffs oldVersion newVersion root = do
       case Map.lookup (N.fromChars moduleNameString) interfaces of
         Just interface -> do
           debug $ "starting generatefor"
-          generateFor coreTypeDiffs oldVersion newVersion interfaces (interfaces Sanity.! (N.fromChars $ "Evergreen.V" <> show newVersion <> ".Types"))
+          generateFor onlyPreserveBackend coreTypeDiffs oldVersion newVersion interfaces (interfaces Sanity.! (N.fromChars $ "Evergreen.V" <> show newVersion <> ".Types"))
 
         Nothing ->
           error $ "Fatal: could not find the module `" <> moduleNameString <> "`, please report this issue in Discord with your project code."
 
     pure $ Ext.ElmFormat.formatOrPassthrough res
 
-generateFor :: CoreTypeDiffs -> Int -> Int -> Interfaces -> Interface.Interface -> IO Text
-generateFor coreTypeDiffs oldVersion newVersion interfaces iface_Types = do
+generateFor :: Bool -> CoreTypeDiffs -> Int -> Int -> Interfaces -> Interface.Interface -> IO Text
+generateFor onlyPreserveBackend coreTypeDiffs oldVersion newVersion interfaces iface_Types = do
   let
     moduleName :: ModuleName.Canonical
     moduleName = ModuleName.Canonical (Pkg.Name "author" "project") (N.fromChars $ "Evergreen.V" <> show newVersion <> ".Types")
 
     migrationModuleText = T.concat ["Evergreen.Migrate.V", show_ newVersion]
 
+    typeDidChange t oldHash newHash =
+      oldHash /= newHash && not (onlyPreserveBackend && t /= N.fromChars "BackendModel")
+
     coreMigrations :: [(N.Name, Migration)]
     coreMigrations =
       coreTypeDiffs
         & fmap (\(t, oldHash, newHash) ->
-            (t, coreTypeMigration (oldHash /= newHash) oldVersion newVersion interfaces moduleName t iface_Types)
+            (t, coreTypeMigration (typeDidChange t oldHash newHash) oldVersion newVersion interfaces moduleName t iface_Types)
         )
   pure $ migrationsToFile migrationModuleText oldVersion newVersion coreMigrations moduleName
 


### PR DESCRIPTION
When set, the generated migration file uses ModelUnchanged/MsgUnchanged for all types except BackendModel, which gets the normal auto-generated migration.  Useful when iterating on frontend types without caring about their migration continuity.  Fixes #66.
