### PR TITLE
Avoid duplicate Platform initializer in generated JavaScript

### DIFF
--- a/extra/Lamdera/Injection.hs
+++ b/extra/Lamdera/Injection.hs
@@ -61,34 +61,56 @@ versionsComment =
 
 graphModifications :: Mode.Mode -> Mains -> Map.Map Opt.Global Opt.Node -> Map.Map Opt.Global Opt.Node
 graphModifications mode mains graph = do
-  if mains & mainsInclude ["Lamdera.Live"]
-    then graph & Map.mapWithKey (modify $ isOptimizedMode mode)
-           -- & inspect
-    else graph
+  graph
+    & Map.mapWithKey (modify (mains & mainsInclude ["Lamdera.Live"]) $ isOptimizedMode mode)
+    -- & inspect
 
 
-modify :: Bool -> Opt.Global -> Opt.Node -> Opt.Node
-modify isOptimized v n =
+modify :: Bool -> Bool -> Opt.Global -> Opt.Node -> Opt.Node
+modify isLamderaLive isOptimized v n =
   case (v, n) of
+    (Opt.Global (ModuleName.Canonical (Pkg.Name "elm" "kernel") name) _, Opt.Kernel chunks deps)
+      | name `elem` ["Browser", "Debugger", "Platform"] ->
+          Opt.Kernel (chunks & fmap renameLamderaPlatformInitialize) deps
+
     (Opt.Global (ModuleName.Canonical (Pkg.Name "elm" "kernel") "Http") name, Opt.Kernel chunks deps) ->
-      let newChunks =
-              chunks & fmap (\chunk ->
-                case chunk of
-                  Elm.Kernel.JS bs | bs & Text.decodeUtf8 & Text.isInfixOf "var _Http_toTask =" ->
-                    bs
-                      & Text.decodeUtf8
-                      & Text.replace "var _Http_toTask =" "var _Http_toTask_REPLACED ="
-                      & (<>) (modifiedHttp_toTask isOptimized)
-                      & Text.encodeUtf8
-                      & Elm.Kernel.JS
-                  _ ->
-                    chunk
-              )
-      in
-      Opt.Kernel newChunks deps
+      if not isLamderaLive then
+        n
+      else
+        let newChunks =
+                chunks & fmap (\chunk ->
+                  case chunk of
+                    Elm.Kernel.JS bs | bs & Text.decodeUtf8 & Text.isInfixOf "var _Http_toTask =" ->
+                      bs
+                        & Text.decodeUtf8
+                        & Text.replace "var _Http_toTask =" "var _Http_toTask_REPLACED ="
+                        & (<>) (modifiedHttp_toTask isOptimized)
+                        & Text.encodeUtf8
+                        & Elm.Kernel.JS
+                    _ ->
+                      chunk
+                )
+        in
+        Opt.Kernel newChunks deps
 
     _ ->
       n
+
+
+renameLamderaPlatformInitialize :: Elm.Kernel.Chunk -> Elm.Kernel.Chunk
+renameLamderaPlatformInitialize chunk =
+  case chunk of
+    Elm.Kernel.JS bs ->
+      bs
+        & Text.decodeUtf8
+        & Text.replace "function _Platform_initialize(" "function _Platform_initialize_Lamdera("
+        & Text.replace "return _Platform_initialize(" "return _Platform_initialize_Lamdera("
+        & Text.replace "return __Platform_initialize(" "return _Platform_initialize_Lamdera("
+        & Text.encodeUtf8
+        & Elm.Kernel.JS
+
+    _ ->
+      chunk
 
 
 {- Approach taken from cors-anywhere:


### PR DESCRIPTION
## Summary

- Rename Lamdera's replacement Platform initializer to `_Platform_initialize_Lamdera` before kernel chunks are emitted.
- Rewrite Lamdera replacement Browser/Debugger/Platform call sites to use that Lamdera-specific initializer name.
- Keep the existing Lamdera Live HTTP kernel patch scoped to Lamdera Live builds only.

Fixes #97.

## Why

`lamdera make --no-wire` currently emits a second global `_Platform_initialize` from the Lamdera replacement `elm/core` kernel. Downstream tooling such as `elm-watch` patches the standard compiler `_Platform_initialize`, but the later Lamdera declaration can override that patched function at runtime.

Using a Lamdera-specific initializer name preserves Lamdera's replacement runtime behavior without shadowing the compiler runtime name that downstream tools may patch.

## Test plan

- Verified in a downstream Elm Land app that raw Lamdera output currently contains two `_Platform_initialize` definitions and that elm-watch rewrites only the first.
- Verified that renaming the Lamdera replacement initializer removes the duplicate active `_Platform_initialize` shape from transformed output.
- Attempted `stack build --fast` locally. The build did not reach this change; it failed in third-party C/native dependencies on macOS (`hashable`, `hfsevents`, `entropy`) against the local SDK/toolchain.


Made with [Cursor](https://cursor.com)