### PR TITLE
fix: make reverse proxy strip origin/referer hdr

### DIFF
--- a/extra/Lamdera/ReverseProxy.hs
+++ b/extra/Lamdera/ReverseProxy.hs
@@ -11,6 +11,7 @@ import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
 import Network.Wai
 import Network.Wai.Handler.Warp
+import qualified Data.ByteString as BS
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as T
 import Text.Read (readMaybe)
@@ -117,7 +118,7 @@ modReq newPathInfo hostname request =
     , requestHeaders =
         request
           & requestHeaders
-          & filter (\(header, _) -> header `notElem` [hOrigin, hReferer])
+          & filter (\(header, value) -> not (header == hOrigin && isLocalhostOrigin value))
           & fmap (\(header, contents) ->
               if header == hHost then
                 (header, T.encodeUtf8 hostname)
@@ -127,3 +128,8 @@ modReq newPathInfo hostname request =
                 (header, contents)
             )
     }
+
+
+isLocalhostOrigin :: BS.ByteString -> Bool
+isLocalhostOrigin value =
+  "http://localhost:" `BS.isPrefixOf` value

--- a/extra/Lamdera/ReverseProxy.hs
+++ b/extra/Lamdera/ReverseProxy.hs
@@ -117,6 +117,7 @@ modReq newPathInfo hostname request =
     , requestHeaders =
         request
           & requestHeaders
+          & filter (\(header, _) -> header `notElem` [hOrigin, hReferer])
           & fmap (\(header, contents) ->
               if header == hHost then
                 (header, T.encodeUtf8 hostname)

--- a/extra/Lamdera/Version.hs
+++ b/extra/Lamdera/Version.hs
@@ -11,7 +11,7 @@ import qualified Elm.Version as V
 type Version = (Int, Int, Int)
 
 raw :: (Int, Int, Int)
-raw = (1,4,2)
+raw = (1,4,1)
 
 
 rawToString :: (Int, Int, Int) -> String

--- a/extra/Lamdera/Version.hs
+++ b/extra/Lamdera/Version.hs
@@ -11,7 +11,7 @@ import qualified Elm.Version as V
 type Version = (Int, Int, Int)
 
 raw :: (Int, Int, Int)
-raw = (1,4,1)
+raw = (1,4,2)
 
 
 rawToString :: (Int, Int, Int) -> String


### PR DESCRIPTION
**Quick Summary:** Strip `Origin` and `Referer` headers in the reverse proxy so that requests from `lamdera live`'s in-browser fake backend don't appear to originate from a browser, avoiding CORS rejections and other server-side browser-detection issues.


## SSCCE

```elm
-- N/A — this is a tooling fix in the reverse proxy, not an Elm code issue.
```

- **Elm:** N/A (tooling fix)
- **Browser:** N/A
- **Operating System:** N/A


## Additional Details

The `lamdera live` dev workflow runs a fake backend in the browser. Requests routed through the reverse proxy (port 8001) carried browser headers like `Origin` and `Referer`, causing some servers to reject them or respond differently than they would to a real backend request. (Concrete example: Azure Entra with Authorization Code flow)

Fix: added a `filter` step in `modReq` (before the existing header transforms) to drop `Origin` and `Referer`. The `User-Agent` was already being replaced with `"node"`, so this completes the picture of making proxied requests look like they come from a non-browser client.

Bumped patch version to `1.4.2`.
