### PR TITLE
Fix a race condition for file o.dat

### DIFF
--- a/terminal/src/Develop.hs
+++ b/terminal/src/Develop.hs
@@ -327,8 +327,8 @@ compile path =
           return $ Left $ Exit.ReactorNoOutline
 
         Just root ->
-          BW.withScope $ \scope -> Stuff.withRootLock root $ Task.run $
-            do  details <- Task.eio Exit.ReactorBadDetails $ Details.load Reporting.silent scope root
+          Stuff.withRootLock root $ Task.run $
+            do  details <- Task.eio Exit.ReactorBadDetails $ BW.withScope $ \scope -> Details.load Reporting.silent scope root
                 artifacts <- Task.eio Exit.ReactorBadBuild $ Build.fromPaths Reporting.silent root details (NE.List path [])
 
                 Lamdera.PostCompile.check details artifacts Exit.ReactorBadBuild


### PR DESCRIPTION
Sometimes, for an empty "elm-stuff" folder, it happened that the compiler tried to read the file "o.dat" before the background writer had created it.

This fix narrows the scope of the `BackgroundWriter` to just the `Details.load` call. The following `Lamdera.PostCompile.check` and `Lamdera.TypeHash.buildCheckHashes` calls can then assume that the file "o.dat" has been created already.