### PR TITLE
Ignore changes to .jj/ and .watchman-cookie-*

### DIFF
--- a/ext-sentry/Ext/Filewatch.hs
+++ b/ext-sentry/Ext/Filewatch.hs
@@ -49,6 +49,8 @@ watch root action = do
           -- https://github.com/haskell-fswatch/hfsnotify/issues/101
           shouldRefresh = do
                 not (List.isInfixOf ".git" filepath)
+             && not (List.isInfixOf ".jj" filepath)
+             && not (List.isInfixOf ".watchman-cookie-" filepath)
              && not (List.isInfixOf "elm-stuff" filepath)
              && not (List.isInfixOf "node_modules" filepath)
             --  This is really dumb of you because some people use `/data/...` as a folder...


### PR DESCRIPTION
**Quick Summary:**

Jujutsu, possibly with watchman configured, causes `lamdera live` to constantly reload.

## Additional Details

This may be additionally caused by the configuration of https://www.jj-vcs.dev/latest/config/#watchman with Jujutsu, however the gist of what happens is a file starting with the name `.watchman-cookie-` gets created and a few directories within `.jj/` are created/modified. This triggers Lamdera to reload essentially continuously. By ignoring `.jj` and `.watchman-cookie-` the error goes away.

This can be tested by installing Jujutsu and then running `jj git init --colocate` within any Lamdera project, then run `lamdera live` and open localhost.