### PR TITLE
lamdera live: Switch order of new-leader broadcast and disconnect broadcast

### DIFF
--- a/extra/SocketServer.hs
+++ b/extra/SocketServer.hs
@@ -60,9 +60,6 @@ socketHandler mClients mLeader beState onJoined onReceive clientId sessionId pen
 
           pure changed
 
-        -- Lamdera.debugT ("[websocket] 🚫 " <> clientId)
-        SocketServer.broadcastImpl mClients $ "{\"t\":\"d\",\"s\":\"" <> sessionId <> "\",\"c\":\""<> clientId <> "\"}"
-
         onlyWhen leaderChanged $ do
           sendToLeader mClients mLeader (\leader -> do
               -- Tell the new leader about the backend state they need
@@ -70,6 +67,10 @@ socketHandler mClients mLeader beState onJoined onReceive clientId sessionId pen
             )
           -- Tell everyone about the new leader (also causes actual leader to go active as leader)
           broadcastLeader mClients mLeader
+
+        -- Broadcast the disconnect (after the election of a new leader so it can process the disconnect event).
+        -- Lamdera.debugT ("[websocket] 🚫 " <> clientId)
+        SocketServer.broadcastImpl mClients $ "{\"t\":\"d\",\"s\":\"" <> sessionId <> "\",\"c\":\""<> clientId <> "\"}"
 
         pure ()
 


### PR DESCRIPTION
This fixes a bug where:

1. a leader joins
2. a follower joins
3. a leader closes the browser tab
4. a disconnect is broadcast (but there is no leader to act on it)
5. a new leader is broadcast

We switch the steps 4 and 5, so that the new leader can act on the disconnect message.